### PR TITLE
Fixed error on mapping for :Tabularize /|

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -349,8 +349,8 @@
           vmap <Leader>a:: :Tabularize /:\zs<CR>
           nmap <Leader>a, :Tabularize /,<CR>
           vmap <Leader>a, :Tabularize /,<CR>
-          nmap <Leader>a| :Tabularize /|<CR>
-          vmap <Leader>a| :Tabularize /|<CR>
+          nmap <Leader>a<Bar> :Tabularize /<Bar><CR>
+          vmap <Leader>a<Bar> :Tabularize /<Bar><CR>
         endif
      " }
 


### PR DESCRIPTION
Hi,

I had problems with vim complaining about `:Tabularize /|` not existing. After a quick check in `:h` I saw that including the bar in a mappings need scaping. That's what fixed the issue for me on my dotfiles franciscoj/dot-files@cb501c3, so I hope it helps for you too.

PS: Thanks a lot for sharing this :D 
