### PR TITLE
Fix directory typo when trying to build Command-T

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -103,6 +103,7 @@
 	set virtualedit=onemore 	   	" allow for cursor beyond last character
 	set history=1000  				" Store a ton of history (default is 20)
 	set spell 		 	        	" spell checking on
+	set hidden 		 	        	" allow buffer swtiching without saving
 
 	" Setting up the directories {
 		set backup 						" backups are nice ...

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -34,5 +34,5 @@ vim +BundleInstall! +BundleClean +q
 # Build command-t for your system
 echo "building command-t executable\n"
 echo "command-t depends on ruby and rake to be present\n"
-cd $HOME/.vim/bundle/Command-t
+cd $HOME/.vim/bundle/Command-T
 (rake make) || warn "Ruby compilation failed. Ruby, GCC or rake not installed?"


### PR DESCRIPTION
1- On my config (zsh), bootstrap.sh can't cd into $HOME/.vim/bundle/Command-t, because the directory spell with a 'T' and not a 't'. This PR fix the bug.

2- Added "set hidden": useful when switching buffer, because without it, you need to save the file before jumping to another buffer.

Thanks !
