### PR TITLE
Change js to javascript in autocmd FileType c,cpp,java,php,js,python,rub...

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -228,7 +228,7 @@
     set pastetoggle=<F12>           " pastetoggle (sane indentation on pastes)
     "set comments=sl:/*,mb:*,elx:*/  " auto format comment blocks
     " Remove trailing whitespaces and ^M chars
-    autocmd FileType c,cpp,java,php,js,python,twig,xml,yml autocmd BufWritePre <buffer> :call setline(1,map(getline(1,"$"),'substitute(v:val,"\\s\\+$","","")'))
+    autocmd FileType c,cpp,java,php,javascript,python,twig,xml,yml autocmd BufWritePre <buffer> :call setline(1,map(getline(1,"$"),'substitute(v:val,"\\s\\+$","","")'))
 " }
 
 " Key (re)Mappings {


### PR DESCRIPTION
...y autocmd BufWritePre :call setline(1,map(getline(1,"$"),'substitute(v:val,"\s+$","","")')) to support Javascript file.
