### PR TITLE
source support_function.vim or you will meet the "JavaClassNameFromFilen...

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -84,6 +84,8 @@
             Bundle 'scrooloose/syntastic'
             Bundle 'garbas/vim-snipmate'
             Bundle 'spf13/snipmate-snippets'
+            " Source support_function.vim to support snipmate-snippets.
+            source $HOME/.vim/bundle/snipmate-snippets/snippets/support_functions.vim 
             Bundle 'tpope/vim-fugitive'
             Bundle 'scrooloose/nerdcommenter'
             Bundle 'godlygeek/tabular'


### PR DESCRIPTION
...ame Not Found" error when you try to complete the java class snippet.
