### PR TITLE
git clone using http:// rather than git://, for people behind firewall

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,7 +20,7 @@ for i in $HOME/.vim $HOME/.vimrc $HOME/.gvimrc; do [ -e $i ] && mv $i $i.$today;
 
 
 echo "cloning spf13-vim\n"
-git clone --recursive -b 3.0 git://github.com/spf13/spf13-vim.git $endpath
+git clone --recursive -b 3.0 http://github.com/spf13/spf13-vim.git $endpath
 mkdir -p $endpath/.vim/bundle
 ln -s $endpath/.vimrc $HOME/.vimrc
 ln -s $endpath/.vim $HOME/.vim


### PR DESCRIPTION
for people behind firewall, the git:// does not work. Hence the git clone should be used with http:// to avoid any problem.
