### PR TITLE
Point bootstrap.sh to the correct interpreter.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/env sh
+#!/usr/bin/env sh
 
 endpath="$HOME/.spf13-vim-3"
 


### PR DESCRIPTION
Bootstrap.sh is pointing to `/bin/env` instead of `/usr/bin/env`
