### PR TITLE
Changed rails.vim bundle location from vimscripts to the original authors git repository.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -130,7 +130,7 @@
 
     " Ruby
         if count(g:spf13_bundle_groups, 'ruby')
-            Bundle 'rails.vim'
+            Bundle 'tpope/vim-rails'
         endif
 
     " Misc


### PR DESCRIPTION
The vimscripts repository is lacking a neccessary file and therefore defective.
