### PR TITLE
Removed mkview calls because they are breaking navigation commands in rails.vim

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -130,7 +130,7 @@
 
     " Ruby
         if count(g:spf13_bundle_groups, 'ruby')
-            Bundle 'rails.vim'
+            Bundle 'tpope/vim-rails'
         endif
 
     " Misc

--- a/.vimrc
+++ b/.vimrc
@@ -170,9 +170,6 @@
             set undolevels=1000         "maximum number of changes that can be undone
             set undoreload=10000        "maximum number lines to save for undo on a buffer reload
         endif
-        " Could use * rather than *.*, but I prefer to leave .files unsaved
-        au BufWinLeave *.* silent! mkview  "make vim save view (state) (folds, cursor, etc)
-        au BufWinEnter *.* silent! loadview "make vim load view (state) (folds, cursor, etc)
     " }
 " }
 


### PR DESCRIPTION
The use of mkview seems to break the navigation commands in rails.vim. Most uses of navigation commands creating those errors: "E345: Can't find file “xxx” in path"

A bugreport in the upstream project indicates that the calls to mkview are cause of the errors (https://github.com/tpope/vim-rails/issues/25).
Removing those fixed the problem for me.
