### PR TITLE
Add guifont format for gtk2

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -538,7 +538,11 @@
     if has('gui_running')
         set guioptions-=T           " remove the toolbar
         set lines=40                " 40 lines of text instead of 24,
-        set guifont=Andale\ Mono\ Regular:h16,Menlo\ Regular:h15,Consolas\ Regular:h16,Courier\ New\ Regular:h18
+        if has("gui_gtk2")
+            set guifont=Andale\ Mono\ Regular\ 16,Menlo\ Regular\ 15,Consolas\ Regular\ 16,Courier\ New\ Regular\ 18
+        else
+            set guifont=Andale\ Mono\ Regular:h16,Menlo\ Regular:h15,Consolas\ Regular:h16,Courier\ New\ Regular:h18
+        endif
         if has('gui_macvim')
             set transparency=5          " Make the window slightly transparent
         endif


### PR DESCRIPTION
Gvim doesn't appear to support the ":h" delimiter in the guifont setting and instead requires an escaped space "\ ". Because of this, when you load the default spf13-vim on Ubuntu 11.10 (and probably 12.04 although can't check atm) the spacing between each character is much larger due to it being unable to understand the guifont format.

This patch fixes that issue.

You can see a example of the problem on this stack overflow page: http://stackoverflow.com/questions/3539437/gvim-ubuntu-letter-spacing-consolas-font

Thanks for making spf13-vim :)
