### PR TITLE
Fix CSApprox when run inside xterm or screen/tmux

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -547,6 +547,9 @@
             set transparency=5          " Make the window slightly transparent
         endif
     else
+        if &term == 'xterm' || &term == 'screen'
+            set t_Co=256                 " Enable 256 colors to stop the CSApprox warning and make xterm vim shine
+        endif
         "set term=builtin_ansi       " Make arrow and other keys work
     endif
 " }


### PR DESCRIPTION
Quick Note: I don't own an OSX or Windows machine so I'm not in a position where I can test them. I don't imagine it would have a negative effect on either, however I'm just letting you know. If you can it might be an idea to try running vim within screen on OSX to see if it causes any problems.

...and so on with the fix...

Currently on Ubuntu and probably other distros, 256 colors is not enabled
in terminal Vim. Because of this CSApprox issues the following warning
every time the user starts vim from the within xterm or a screen/tmux
session:

> CSApprox skipped; terminal only has 8 colors, not 88/256
> Try checking :help csapprox-terminal for workarounds

This fix adds a check of the terminal being used and if it's xterm or
screen (tmux also identifies itself as such) then we set t_Co to
256 colors. I think thinks is reasonable as xterm has supported 256
colors for about 13 years now.
