### PR TITLE
Use ack-grep in the Ack plugin when suitable.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -42,7 +42,10 @@
         Bundle 'gmarik/vundle'
         Bundle 'MarcWeber/vim-addon-mw-utils'
         Bundle 'tomtom/tlib_vim'
-        if executable('ack')
+        if executable('ack-grep')
+            let g:ackprg="ack-grep -H --nocolor --nogroup --column"
+            Bundle 'mileszs/ack.vim'
+        elseif executable('ack')
             Bundle 'mileszs/ack.vim'
         endif
 

--- a/.vimrc
+++ b/.vimrc
@@ -99,6 +99,7 @@
                 Bundle 'majutsushi/tagbar'
             endif
             Bundle 'Shougo/neocomplcache'
+            Bundle 'Shougo/neocomplcache-snippets-complete'
         endif
 
     " PHP

--- a/.vimrc
+++ b/.vimrc
@@ -102,7 +102,6 @@
                 Bundle 'majutsushi/tagbar'
             endif
             Bundle 'Shougo/neocomplcache'
-            Bundle 'Shougo/neocomplcache-snippets-complete'
         endif
 
     " PHP


### PR DESCRIPTION
On Ubuntu (at least on 12.04) the ack utility executable name is ack-grep,
current .vimrc checks only if an executable named ack exists.
Submitting this request following the discussion here https://groups.google.com/forum/#!topic/spf13-vim-discuss/krzn-VdotFs%5B1-25%5D

Note that I had an earlier pull request for the neocomplcache-snippets-complete,
I have reverted that change, so this request also includes the commit and the revert-commit for neocomplcache,
sorry for the mess...
