### PR TITLE
Use amirh/HTML-AutoCloseTag instead of HTML-AutoCloseTag

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -124,7 +124,7 @@
 
     " HTML
         if count(g:spf13_bundle_groups, 'html')
-            Bundle 'HTML-AutoCloseTag'
+            Bundle 'amirh/HTML-AutoCloseTag'
             Bundle 'ChrisYip/Better-CSS-Syntax-for-Vim'
         endif
 


### PR DESCRIPTION
This fixes a bug in the use of AutoCloseTag when the completion menu is
visible.
Description of the bug:
https://groups.google.com/forum/#!topic/spf13-vim-discuss/g-tkIbMzvFM%5B1-25%5D
