### PR TITLE
Use ack-grep in the Ack plugin when suitable.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -42,7 +42,10 @@
         Bundle 'gmarik/vundle'
         Bundle 'MarcWeber/vim-addon-mw-utils'
         Bundle 'tomtom/tlib_vim'
-        if executable('ack')
+        if executable('ack-grep')
+            let g:ackprg="ack-grep -H --nocolor --nogroup --column"
+            Bundle 'mileszs/ack.vim'
+        elseif executable('ack')
             Bundle 'mileszs/ack.vim'
         endif
 


### PR DESCRIPTION
As the ack utility executable file in Ubuntu is ack-grep
Check for this name also (and not only for ack) before deciding whether to include the Ack bundle.

See this discussion: 
https://groups.google.com/forum/#!topic/spf13-vim-discuss/krzn-VdotFs%5B1-25%5D
