### PR TITLE
after bundle install, close all buffers.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -29,4 +29,4 @@ echo "Installing Vundle"
 git clone http://github.com/gmarik/vundle.git $HOME/.vim/bundle/vundle
 
 echo "installing plugins using Vundle"
-vim +BundleInstall! +BundleClean +q
+vim +BundleInstall! +BundleClean +qall


### PR DESCRIPTION
Hi

when we do `:BundleInstall`, current version vundle create new buffer.
so we need close all buffers.
