### PR TITLE
Separate snippets to make it easier to override

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -58,7 +58,7 @@
     " In your .vimrc.bundles.local file"
     " list only the plugin groups you will use
     if !exists('g:spf13_bundle_groups')
-        let g:spf13_bundle_groups=['general', 'programming', 'php', 'ruby', 'python', 'javascript', 'html', 'misc']
+        let g:spf13_bundle_groups=['general', 'snippets', 'programming', 'php', 'ruby', 'python', 'javascript', 'html', 'misc']
     endif
 
     " To override all the included bundles, put
@@ -84,12 +84,16 @@
             Bundle 'corntrace/bufexplorer'
         endif
 
+    " Snippets 
+        if count(g:spf13_bundle_groups, 'snippets')
+            Bundle 'spf13/snipmate-snippets'
+        endif
+
     " General Programming
         if count(g:spf13_bundle_groups, 'programming')
             " Pick one of the checksyntax, jslint, or syntastic
             Bundle 'scrooloose/syntastic'
             Bundle 'garbas/vim-snipmate'
-            Bundle 'spf13/snipmate-snippets'
             " Source support_function.vim to support snipmate-snippets.
             if filereadable(expand("~/.vim/bundle/snipmate-snippets/snippets/support_functions.vim"))
                 source ~/.vim/bundle/snipmate-snippets/snippets/support_functions.vim


### PR DESCRIPTION
I think the snippets bundle should be defined on its own so that it's easier to override with your own in .vimrc.bundles.local.
