### PR TITLE
Don't use cmaps for one letter command fixes.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -283,10 +283,10 @@
     map <S-L> gt
 
     " Stupid shift key fixes
-    cmap W w
-    cmap WQ wq
-    cmap wQ wq
-    cmap Q q
+    command -nargs=* -complete=file W w <args>
+    command -nargs=* -complete=file Q q <args>
+    command -nargs=* -complete=file WQ wq <args>
+    command -nargs=* -complete=file Wq wq <args>
     cmap Tabe tabe
 
     " Yank from the cursor to the end of the line, to be consistent with C and D.


### PR DESCRIPTION
As the vimrc is written the cmaps will change any capital W or Q to
lower case. This has the nasty side effect of breaking any functions
with upper case W or Q (e.g., FixWhitespace).

The correct solution is to use commands. The only side effect here is
that all commands must start with an upper case letter.

Addresses #124
