### PR TITLE
Allow users to disable views.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -183,9 +183,12 @@
             set undolevels=1000         "maximum number of changes that can be undone
             set undoreload=10000        "maximum number lines to save for undo on a buffer reload
         endif
+
+    if !exists('g:spf13_no_views')
         " Could use * rather than *.*, but I prefer to leave .files unsaved
         au BufWinLeave *.* silent! mkview  "make vim save view (state) (folds, cursor, etc)
         au BufWinEnter *.* silent! loadview "make vim load view (state) (folds, cursor, etc)
+    endif
     " }
 " }
 

--- a/.vimrc
+++ b/.vimrc
@@ -184,6 +184,9 @@
             set undoreload=10000        "maximum number lines to save for undo on a buffer reload
         endif
 
+    " To disable views set
+    " g:spf13_no_views = 1
+    " in your .vimrc.bundles.local file"
     if !exists('g:spf13_no_views')
         " Could use * rather than *.*, but I prefer to leave .files unsaved
         au BufWinLeave *.* silent! mkview  "make vim save view (state) (folds, cursor, etc)


### PR DESCRIPTION
There are several plugins that do not play well with views. Rather then
remove views entirely, allow users to disable them in their
vimrc.bundle.local. Provides an alternative to #96.
