### PR TITLE
filetype needs to be off before loading vundle

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -30,7 +30,8 @@
     " }
     "
     " Setup Bundle Support {
-    " The next two lines ensure that the ~/.vim/bundle/ system works
+    " The next three lines ensure that the ~/.vim/bundle/ system works
+        filetype off
         set rtp+=~/.vim/bundle/vundle
         call vundle#rc()
     " }


### PR DESCRIPTION
There are a variety of problems that can occur when the directive
'filetype on' is set and vundle/pathogen are then loaded. Explicitly
turning off filetype before loading is the recommended behavior.

I think this generally happens on systems where the distribution does
filetype magic. So its not likely to be seen on Mac or Windows. But is
an issue on Linux package installs.

Its now part of the recommended way to load vundle and is briefly
covered in gmarik/vundle#16.
