### PR TITLE
Fixed case of "leader"

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -350,7 +350,7 @@
     map <leader>et :tabe %%
 
     " Adjust viewports to the same size
-    map <Leader>= <C-w>=
+    map <leader>= <C-w>=
 
     " Easier horizontal scrolling
     map zl zL
@@ -401,7 +401,7 @@
     " AutoCloseTag {
         " Make it so AutoCloseTag works for xml and xhtml files as well
         au FileType xhtml,xml ru ftplugin/html/autoclosetag.vim
-        nmap <Leader>ac <Plug>ToggleAutoCloseMappings
+        nmap <leader>ac <Plug>ToggleAutoCloseMappings
     " }
 
     " SnipMate {
@@ -425,16 +425,16 @@
 
     " Tabularize {
         if exists(":Tabularize")
-          nmap <Leader>a= :Tabularize /=<CR>
-          vmap <Leader>a= :Tabularize /=<CR>
-          nmap <Leader>a: :Tabularize /:<CR>
-          vmap <Leader>a: :Tabularize /:<CR>
-          nmap <Leader>a:: :Tabularize /:\zs<CR>
-          vmap <Leader>a:: :Tabularize /:\zs<CR>
-          nmap <Leader>a, :Tabularize /,<CR>
-          vmap <Leader>a, :Tabularize /,<CR>
-          nmap <Leader>a<Bar> :Tabularize /<Bar><CR>
-          vmap <Leader>a<Bar> :Tabularize /<Bar><CR>
+          nmap <leader>a= :Tabularize /=<CR>
+          vmap <leader>a= :Tabularize /=<CR>
+          nmap <leader>a: :Tabularize /:<CR>
+          vmap <leader>a: :Tabularize /:<CR>
+          nmap <leader>a:: :Tabularize /:\zs<CR>
+          vmap <leader>a:: :Tabularize /:\zs<CR>
+          nmap <leader>a, :Tabularize /,<CR>
+          vmap <leader>a, :Tabularize /,<CR>
+          nmap <leader>a<Bar> :Tabularize /<Bar><CR>
+          vmap <leader>a<Bar> :Tabularize /<Bar><CR>
 
           " The following function automatically aligns when typing a
           " supported character


### PR DESCRIPTION
Fixed "leader" from upper to lower case in `.vimrc` file.
