### PR TITLE
Add support for .fork customizations

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -44,6 +44,11 @@
             source ~/.vimrc.bundles.local
         endif
     " }
+    " Use fork bundles if available {
+        if filereadable(expand("~/.vimrc.bundles.fork"))
+            source ~/.vimrc.bundles.fork
+        endif
+    " }
     " Use bundles config {
         if filereadable(expand("~/.vimrc.bundles"))
             source ~/.vimrc.bundles
@@ -537,6 +542,11 @@ function! NERDTreeInitAsNeeded()
 endfunction
 " }
 
+" Use fork vimrc if available {
+    if filereadable(expand("~/.vimrc.fork"))
+        source ~/.vimrc.local
+    endif
+" }
 " Use local vimrc if available {
     if filereadable(expand("~/.vimrc.local"))
         source ~/.vimrc.local

--- a/.vimrc
+++ b/.vimrc
@@ -544,7 +544,7 @@ endfunction
 
 " Use fork vimrc if available {
     if filereadable(expand("~/.vimrc.fork"))
-        source ~/.vimrc.local
+        source ~/.vimrc.fork
     endif
 " }
 " Use local vimrc if available {

--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -55,6 +55,11 @@
             source ~/.vimrc.bundles.local
         endif
     " }
+    " Use fork bundles if available {
+        if filereadable(expand("~/.vimrc.bundles.fork"))
+            source ~/.vimrc.bundles.fork
+        endif
+    " }
 
     " In your .vimrc.bundles.local file"
     " list only the plugin groups you will use


### PR DESCRIPTION
By adding a second tier of customization I can maintain some overriding options in a fork that I can use from multiple computers and share with my coworkers without needing to change anything in the core spf13-vim repo, making it much easier to remain in sync with the origin
