### PR TITLE
system clipboard => default for vim

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -19,6 +19,10 @@
     " Basics {
         set nocompatible        " must be first line
         set background=dark     " Assume a dark background
+        
+        " use the system clipboard as default clipboard.
+        set clipboard=unnamed
+
     " }
 
     " Windows Compatible {


### PR DESCRIPTION
This also works for console vim, as long as it has gui built-in.
On mac, i use mvim -v.

http://vim.wikia.com/wiki/Accessing_the_system_clipboard
