### PR TITLE
Add symlinks to .fork files in installer

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -36,7 +36,9 @@ fi
 
 echo "setting up symlinks"
 lnif $endpath/.vimrc $HOME/.vimrc
+lnif $endpath/.vimrc.fork $HOME/.vimrc.fork
 lnif $endpath/.vimrc.bundles $HOME/.vimrc.bundles
+lnif $endpath/.vimrc.bundles.fork $HOME/.vimrc.bundles.fork
 lnif $endpath/.vim $HOME/.vim
 if [ ! -d $endpath/.vim/bundle ]; then
     mkdir -p $endpath/.vim/bundle


### PR DESCRIPTION
Added the docs, but we didn't add links to the .fork customization from the installer =]

Unlike the .local files, these are intended to be in source control, just specific to a particular fork.
