### PR TITLE
Change the UndoTreeRemap to c-h

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -496,7 +496,7 @@
      " }
 
      " UndoTree {
-        nnoremap <c-u> :UndotreeToggle<CR>
+        nnoremap <c-h> :UndotreeToggle<CR>
      " }
 
 " }


### PR DESCRIPTION
Change the UndoTreeRemap to c-h, so that UndoTree won't
overwrite the keymapping for scrolling half way up the pag (c-u).
