### PR TITLE
Fix symlink check bug in dotfiles backup.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -22,7 +22,7 @@ echo "Thanks for installing spf13-vim\n"
 # Backup existing .vim stuff
 echo "backing up current vim config\n"
 today=`date +%Y%m%d`
-for i in $HOME/.vim $HOME/.vimrc $HOME/.gvimrc; do [ -e $i ] && [ ! -L $file ] && mv $i $i.$today; done
+for i in $HOME/.vim $HOME/.vimrc $HOME/.gvimrc; do [ -e $i ] && [ ! -L $i ] && mv $i $i.$today; done
 
 
 if [ ! -e $endpath/.git ]; then


### PR DESCRIPTION
I think the following change to bootstrap.sh introduced in commit 2fd2644 to determine if the target is a symlink has a bug?

-for i in $HOME/.vim $HOME/.vimrc $HOME/.gvimrc; do [ -e $i ] && mv $i $i.$today; done
+for i in $HOME/.vim $HOME/.vimrc $HOME/.gvimrc; do [ -e $i ] && [ ! -L $file ] && mv $i $i.$today; done

On my macbook backups are not getting created for my pre-existing vim dotfiles.

I changed $file to $i and it works.
