### PR TITLE
added BundleInstall to the windows installer .cmd file

### DIFF
--- a/spf13-vim-windows-install.cmd
+++ b/spf13-vim-windows-install.cmd
@@ -10,3 +10,4 @@ call mklink %HOME%\_vimrc %BASE_DIR%\.vimrc
 call mklink %HOME%\.vimrc.bundles %BASE_DIR%\.vimrc.bundles
 
 call git clone http://github.com/gmarik/vundle.git %HOME%/.vim/bundle/vundle
+call vim - +BundleInstall! +BundleClean +qall

--- a/spf13-vim-windows-install.cmd
+++ b/spf13-vim-windows-install.cmd
@@ -10,4 +10,4 @@ call mklink %HOME%\_vimrc %BASE_DIR%\.vimrc
 call mklink %HOME%\.vimrc.bundles %BASE_DIR%\.vimrc.bundles
 
 call git clone http://github.com/gmarik/vundle.git %HOME%/.vim/bundle/vundle
-call vim - +BundleInstall! +BundleClean +qall
+call vim -u "$BASE_DIR/.vimrc.bundles" - +BundleInstall! +BundleClean +qall


### PR DESCRIPTION
Hi Steve,

I installed on XP today and found that for some reason the .cmd script does not call BundleInstall. After I launched vim it threw lots of red letters at me.

Fix is pretty simple. I tested on XP only.

cheers,
John
