### PR TITLE
Fix Tabularize Mapping

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -354,34 +354,16 @@
     " }
 
     " Tabularize {
-        if exists(":Tabularize")
-          nmap <Leader>a= :Tabularize /=<CR>
-          vmap <Leader>a= :Tabularize /=<CR>
-          nmap <Leader>a: :Tabularize /:<CR>
-          vmap <Leader>a: :Tabularize /:<CR>
-          nmap <Leader>a:: :Tabularize /:\zs<CR>
-          vmap <Leader>a:: :Tabularize /:\zs<CR>
-          nmap <Leader>a, :Tabularize /,<CR>
-          vmap <Leader>a, :Tabularize /,<CR>
-          nmap <Leader>a<Bar> :Tabularize /<Bar><CR>
-          vmap <Leader>a<Bar> :Tabularize /<Bar><CR>
-
-          " The following function automatically aligns when typing a
-          " supported character
-          inoremap <silent> <Bar>   <Bar><Esc>:call <SID>align()<CR>a
-
-          function! s:align()
-              let p = '^\s*|\s.*\s|\s*$'
-              if exists(':Tabularize') && getline('.') =~# '^\s*|' && (getline(line('.')-1) =~# p || getline(line('.')+1) =~# p)
-                  let column = strlen(substitute(getline('.')[0:col('.')],'[^|]','','g'))
-                  let position = strlen(matchstr(getline('.')[0:col('.')],'.*|\s*\zs.*'))
-                  Tabularize/|/l1
-                  normal! 0
-                  call search(repeat('[^|]*|',column).'\s\{-\}'.repeat('.',position),'ce',line('.'))
-              endif
-          endfunction
-
-        endif
+        nmap <Leader>a= :Tabularize /=<CR>
+        vmap <Leader>a= :Tabularize /=<CR>
+        nmap <Leader>a: :Tabularize /:<CR>
+        vmap <Leader>a: :Tabularize /:<CR>
+        nmap <Leader>a:: :Tabularize /:\zs<CR>
+        vmap <Leader>a:: :Tabularize /:\zs<CR>
+        nmap <Leader>a, :Tabularize /,<CR>
+        vmap <Leader>a, :Tabularize /,<CR>
+        nmap <Leader>a<Bar> :Tabularize /<Bar><CR>
+        vmap <Leader>a<Bar> :Tabularize /<Bar><CR>
      " }
 
      " Session List {

--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -168,6 +168,7 @@
             Bundle 'tpope/vim-markdown'
             Bundle 'spf13/vim-preview'
             Bundle 'tpope/vim-cucumber'
+            Bundle 'quentindecock/vim-cucumber-align-pipes'
             Bundle 'Puppet-Syntax-Highlighting'
         endif
 

--- a/README.markdown
+++ b/README.markdown
@@ -300,17 +300,17 @@ You can learn more about it with :help Ack
 
 **QuickStart** :Ack
 
-## Tabularize
+## [Tabularize]
 
 Tabularize lets you align statements on their equal signs and other characters
 
 **Customizations**:
 
- * `<Leader>a=` :Tabularize /=<CR>
- * `<Leader>a:` :Tabularize /:<CR>
- * `<Leader>a::` :Tabularize /:\zs<CR>
- * `<Leader>a,` :Tabularize /,<CR>
- * `<Leader>a<Bar>` :Tabularize /<Bar><CR>
+ * `<Leader>a= :Tabularize /=<CR>`
+ * `<Leader>a: :Tabularize /:<CR>`
+ * `<Leader>a:: :Tabularize /:\zs<CR>`
+ * `<Leader>a, :Tabularize /,<CR>`
+ * `<Leader>a<Bar> :Tabularize /<Bar><CR>`
 
 ## [Tagbar]
 


### PR DESCRIPTION
:Tabularize is not defined before .vimrc is executed, so that "if" 
statement wasn't running.

That align pipes script for cucumber won't work unless it's in a plugin
file, so I came across the plugin for that and added it to .vimrc.bundles.

Edited the readme to link to tabularize and show the full customizations.
