### PR TITLE
Disabled Annoying Relative Line Numbers By Default

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -89,7 +89,7 @@
             Bundle 'flazz/vim-colorschemes'
             Bundle 'corntrace/bufexplorer'
             Bundle 'mbbill/undotree'
-            Bundle 'myusuf3/numbers.vim'
+            "Bundle 'myusuf3/numbers.vim'
         endif
 
     " General Programming


### PR DESCRIPTION
I think there is no really need for Relative Line Numbers, in case of development/debugging it is more annoying than useful.
