### PR TITLE
Switch from legacy NCC snippets to neosnippets.

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -117,7 +117,7 @@
             endif
         elseif count(g:spf13_bundle_groups, 'neocomplcache')
             Bundle 'Shougo/neocomplcache'
-            Bundle 'Shougo/neocomplcache-snippets-complete'
+            Bundle 'Shougo/neosnippet'
             Bundle 'honza/snipmate-snippets'
         endif
 


### PR DESCRIPTION
neocomplcache-snippets-complete is now a legacy repo. It has been replaced by neosnippet.
