### PR TITLE
Replacing Better-CSS-Syntax-for-Vim with vim-css3-syntax

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -152,7 +152,7 @@
     " HTML
         if count(g:spf13_bundle_groups, 'html')
             Bundle 'amirh/HTML-AutoCloseTag'
-            Bundle 'ChrisYip/Better-CSS-Syntax-for-Vim'
+            Bundle 'hail2u/vim-css3-syntax'
         endif
 
     " Ruby


### PR DESCRIPTION
Better-CSS-Syntax-for-Vim was conflicting with vim-haml on scss files. vim-css3-syntax seems to offer a similar level of css syntax highlighting without these issues.
