### PR TITLE
Removing Better-CSS-Syntax-for-Vim workaround

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -35,14 +35,6 @@
         endif
     " }
 
-    " Filetype Workarounds {
-        " Temporary workaround to Better-CSS-Syntax-for-Vim
-        " See https://github.com/ChrisYip/Better-CSS-Syntax-for-Vim/issues/9
-        " for more information
-        autocmd BufNewFile,BufRead *.scss set filetype=css
-        autocmd BufNewFile,BufRead *.sass set filetype=css
-    " }
-
     " Setup Bundle Support {
     " The next three lines ensure that the ~/.vim/bundle/ system works
         filetype on


### PR DESCRIPTION
Since the plugin has been removed, this workaround is not necessary.
