### PR TITLE
Added symbolic link creation for .vimrc.local and .vimrc.bundles.local

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -36,12 +36,19 @@ fi
 
 echo "setting up symlinks"
 lnif $endpath/.vimrc $HOME/.vimrc
-lnif $endpath/.vimrc.local $HOME/.vimrc.local
 lnif $endpath/.vimrc.fork $HOME/.vimrc.fork
 lnif $endpath/.vimrc.bundles $HOME/.vimrc.bundles
 lnif $endpath/.vimrc.bundles.fork $HOME/.vimrc.bundles.fork
-lnif $endpath/.vimrc.bundles.local $HOME/.vimrc.bundles.local
 lnif $endpath/.vim $HOME/.vim
+
+if [ -e $endpath/.vimrc.local ]; then
+    lnif $endpath/.vimrc.local $HOME/.vimrc.local
+fi
+
+if [ -e $endpath/.vimrc.bundles.local ]; then
+    lnif $endpath/.vimrc.bundles.local $HOME/.vimrc.bundles.local
+fi
+
 if [ ! -d $endpath/.vim/bundle ]; then
     mkdir -p $endpath/.vim/bundle
 fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -40,6 +40,7 @@ lnif $endpath/.vimrc.local $HOME/.vimrc.local
 lnif $endpath/.vimrc.fork $HOME/.vimrc.fork
 lnif $endpath/.vimrc.bundles $HOME/.vimrc.bundles
 lnif $endpath/.vimrc.bundles.fork $HOME/.vimrc.bundles.fork
+lnif $endpath/.vimrc.bundles.local $HOME/.vimrc.bundles.local
 lnif $endpath/.vim $HOME/.vim
 if [ ! -d $endpath/.vim/bundle ]; then
     mkdir -p $endpath/.vim/bundle

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -36,6 +36,7 @@ fi
 
 echo "setting up symlinks"
 lnif $endpath/.vimrc $HOME/.vimrc
+lnif $endpath/.vimrc.local $HOME/.vimrc.local
 lnif $endpath/.vimrc.fork $HOME/.vimrc.fork
 lnif $endpath/.vimrc.bundles $HOME/.vimrc.bundles
 lnif $endpath/.vimrc.bundles.fork $HOME/.vimrc.bundles.fork


### PR DESCRIPTION
When installing/reinstalling using bootstrap.sh:

In case of people having a fork of this project and having added the customization files .vimrc.local and/or .vimrc.bundles.local to their repo, this changes will create a symbolic link similar to what is done to all other configuration files.
