### PR TITLE
Replace slow whitespace trim autocmd.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -175,7 +175,7 @@
     set pastetoggle=<F12>           " pastetoggle (sane indentation on pastes)
     "set comments=sl:/*,mb:*,elx:*/  " auto format comment blocks
     " Remove trailing whitespaces and ^M chars
-    autocmd FileType c,cpp,java,php,javascript,python,twig,xml,yml autocmd BufWritePre <buffer> :call setline(1,map(getline(1,"$"),'substitute(v:val,"\\s\\+$","","")'))
+    autocmd FileType c,cpp,java,php,javascript,python,twig,xml,yml autocmd BufWritePre <buffer> call StripTrailingWhitespace()
     autocmd BufNewFile,BufRead *.html.twig set filetype=html.twig
 " }
 
@@ -577,6 +577,20 @@ function! NERDTreeInitAsNeeded()
         wincmd l
     endif
 endfunction
+
+" Strip whitespace
+function! StripTrailingWhitespace()
+" Preparation: save last search, and cursor position.
+    let _s=@/
+    let l = line(".")
+    let c = col(".")
+" Do the business:
+    %s/\s\+$//e
+" Clean up: restore previous search history, and cursor position
+    let @/=_s
+    call cursor(l, c)
+endfunction
+
 " }
 
 " Use fork vimrc if available {


### PR DESCRIPTION
The autocmd for trimming whitespace was unusably slow, taking several seconds to
save a few hundred line file. Here I've replaced it with another that runs
instantaneously. Additionally it tries to clean up after itself with respect to
search history, etc.
