### PR TITLE
Don't read from stdin when bootstrapping.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -50,4 +50,4 @@ if [ ! -e $HOME/.vim/bundle/vundle ]; then
 fi
 
 echo "update/install plugins using Vundle"
-vim -u $endpath/.vimrc.bundles - +BundleInstall! +BundleClean +qall
+vim -u $endpath/.vimrc.bundles +BundleInstall! +BundleClean +qall


### PR DESCRIPTION
I'm not sure why this was put in, but it's unnecessary and actually broke the
install process in my case. There's no input. Vim just hangs.
