### PR TITLE
Ensure vim uses compatible shell in bootstrap

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -50,4 +50,7 @@ if [ ! -e $HOME/.vim/bundle/vundle ]; then
 fi
 
 echo "update/install plugins using Vundle"
+system_shell=$SHELL
+export SHELL="/bin/sh"
 vim -u $endpath/.vimrc.bundles +BundleInstall! +BundleClean +qall
+export SHELL=$system_shell


### PR DESCRIPTION
If you're using fish or some other shell, this will keep the install from failing.
Should have no adverse affects for most systems.
