### PR TITLE
Fixed windows installation process

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -89,7 +89,7 @@ to verify all good, run:
 
 #### Installing spf13-vim on Windows
 
-The easiest way is to download and run the spf13-vim-windows-install.cmd file.
+The easiest way is to download and run the spf13-vim-windows-install.cmd file. Remember to run this file in **Administrator Mode** if you want the symlinks to be created successfully.
 
 ## Updating to the latest version
 The simpliest (and safest) way to update is to simply rerun the installer. It will completely and non destructively upgrade to the latest version. 

--- a/spf13-vim-windows-install.cmd
+++ b/spf13-vim-windows-install.cmd
@@ -2,12 +2,12 @@
 @if not exist "%HOME%" @set HOME=%USERPROFILE%
 
 @set BASE_DIR=%HOME%\.spf13-vim-3
-call git clone --recursive -b 3.0 git://github.com/spf13/spf13-vim.git %BASE_DIR%
-call mkdir %BASE_DIR%\.vim\bundle
-call mklink /J %HOME%\.vim %BASE_DIR%\.vim
-call mklink %HOME%\.vimrc %BASE_DIR%\.vimrc
-call mklink %HOME%\_vimrc %BASE_DIR%\.vimrc
-call mklink %HOME%\.vimrc.bundles %BASE_DIR%\.vimrc.bundles
+call git clone --recursive -b 3.0 git://github.com/spf13/spf13-vim.git "%BASE_DIR%"
+call mkdir "%BASE_DIR%\.vim\bundle"
+call mklink /J "%HOME%\.vim" "%BASE_DIR%\.vim"
+call mklink "%HOME%\.vimrc" "%BASE_DIR%\.vimrc"
+call mklink "%HOME%\_vimrc" "%BASE_DIR%\.vimrc"
+call mklink "%HOME%\.vimrc.bundles" "%BASE_DIR%\.vimrc.bundles"
 
-call git clone http://github.com/gmarik/vundle.git %HOME%/.vim/bundle/vundle
+call git clone http://github.com/gmarik/vundle.git "%HOME%/.vim/bundle/vundle"
 call vim -u "$BASE_DIR/.vimrc.bundles" - +BundleInstall! +BundleClean +qall

--- a/spf13-vim-windows-install.cmd
+++ b/spf13-vim-windows-install.cmd
@@ -10,4 +10,4 @@ call mklink "%HOME%\_vimrc" "%BASE_DIR%\.vimrc"
 call mklink "%HOME%\.vimrc.bundles" "%BASE_DIR%\.vimrc.bundles"
 
 call git clone http://github.com/gmarik/vundle.git "%HOME%/.vim/bundle/vundle"
-call vim -u "$BASE_DIR/.vimrc.bundles" - +BundleInstall! +BundleClean +qall
+call vim -u "%BASE_DIR%/.vimrc.bundles" +BundleInstall! +BundleClean +qall


### PR DESCRIPTION
I've fixed the "spf13-vim-windows-install.cmd" file to use quotes when calling external commands, or else it breaks if the username has spaces in it (like mine).

Also, the last call to vim installing the bundles had an extra hyphen, which would result in a confusing "reading from stdin" message.

Finally, my Windows 8 throws an error while creating symlinks if not in admin mode. So, I've updated the README to mention running this file via the administrative console.
