### PR TITLE
Disable Pymode's whitespace trimmer.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -380,6 +380,7 @@
 
      " PyMode {
         let g:pymode_lint_checker = "pyflakes"
+        let g:pymode_utils_whitespaces = 0
      " }
 
      " ctrlp {


### PR DESCRIPTION
The pymode whitespace trimmer is both slower and sloppier than the one we
already have and it clobbers the search history. Additionally, if someone has
disabled ours, this one still runs, which is probably not what anyone wants.
