### PR TITLE
Add no_views check to the restore_view line

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -90,7 +90,9 @@
             Bundle 'mbbill/undotree'
             Bundle 'myusuf3/numbers.vim'
             Bundle 'nathanaelkane/vim-indent-guides'
-            Bundle 'vim-scripts/restore_view.vim'
+            if !exists('g:spf13_no_views')
+                Bundle 'vim-scripts/restore_view.vim'
+            endif
             Bundle 'tpope/vim-abolish.git'
         endif
 


### PR DESCRIPTION
d79a454 broke #127 since it removed the actual `mkview` and `loadview` calls. This change adds the check in the bundle file as well so that it gets honored.
