### PR TITLE
CtrlP file search command for Git and Hg repositories

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -390,6 +390,14 @@
         let g:ctrlp_custom_ignore = {
             \ 'dir':  '\.git$\|\.hg$\|\.svn$',
             \ 'file': '\.exe$\|\.so$\|\.dll$' }
+
+        let g:ctrlp_user_command = {
+            \ 'types': {
+                \ 1: ['.git', 'cd %s && git ls-files'],
+                \ 2: ['.hg', 'hg --cwd %s locate -I .'],
+            \ },
+            \ 'fallback': 'find %s -type f'
+        \ }
      "}
 
      " TagBar {


### PR DESCRIPTION
Uses the suggested ctrlp_user_command from the [CtrlP website](http://kien.github.com/ctrlp.vim/) for
searching files in git and Hg repositories that belong to the git or
mercurial repository and ignore files that are ignored by your SCM tool.

Also applies the suggestion from [here](https://github.com/kien/ctrlp.vim/issues/174) to ensure that we include new
untracked files in the search results.
