### PR TITLE
Fix restore_view configuration

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -104,7 +104,7 @@
         " Add exclusions to mkview and loadview
         " eg: *.*, svn-commit.tmp
         let g:skipview_files = [
-            \ '[example pattern]'
+            \ '\[example pattern\]'
             \ ]
     endif
     " }


### PR DESCRIPTION
d79a454f5a47b190c8dc22ac014ffa1034669db2 added stub exclusion patterns to .vimrc that broke restore-views (if `g:skipview_files` is not overridden) because the stub contained unescaped special symbols. This is the minimal fix.

Don't think the stub should be there at all `.vimrc` is meant to be a set of default configs here and this is an example rather than a default?
