### PR TITLE
Use invhlsearch instead of nohlsearch

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -241,8 +241,8 @@
     nmap <leader>f8 :set foldlevel=8<CR>
     nmap <leader>f9 :set foldlevel=9<CR>
 
-    "clearing highlighted search
-    nmap <silent> <leader>/ :nohlsearch<CR>
+    " Toggle search highlighting
+    nmap <silent> <leader>/ :set invhlsearch<CR>
 
     " Shortcuts
     " Change Working Directory to that of the current file


### PR DESCRIPTION
This command toggles the highlight state, allowing the user to turn it off and
on as desired without it automatically turning back on.

I found it very annoying that some random command would set the search pattern
to something common like `\s\+` and suddenly my entire Vim session would be
highlighted. `<leader>/` turned if off but any kind of search related motion (or
running the command again, for example) would turn it back on again.

If the user turns off search highlighting, they probably don't want it to
immediately turn back on. If they do, it's as easy as `<leader>/` again.
