### PR TITLE
symlink override

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,6 +15,9 @@ lnif() {
     if [ ! -e $2 ] ; then
         ln -s $1 $2
     fi
+    if [ -L $2 ] ; then
+        ln -sf $1 $2
+    fi
 }
 
 echo "Thanks for installing spf13-vim"


### PR DESCRIPTION
This fixes Issue https://github.com/spf13/spf13-vim/issues/260

If a old symlink of .vimrc exists the new symlink is created by force.
