### PR TITLE
Added vim-php-namespace for inserting "use" statements

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -127,6 +127,7 @@
     " PHP
         if count(g:spf13_bundle_groups, 'php')
             Bundle 'spf13/PIV'
+            Bundle 'arnaud-lb/vim-php-namespace'
         endif
 
     " Python


### PR DESCRIPTION
Adds support for [vim-php-namespace](https://github.com/arnaud-lb/vim-php-namespace).

Since mapping proposed in the official readme conficts with existing spf13-vim mappings, I proposed a new one.
