### PR TITLE
Remove pymode's "set number"

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -394,6 +394,7 @@
     " PyMode {
         let g:pymode_lint_checker = "pyflakes"
         let g:pymode_utils_whitespaces = 0
+        let g:pymode_options = 0
     " }
 
     " ctrlp {


### PR DESCRIPTION
If pymode_options is set to 1 and "number" is unset, pymode overrides it and sets number for python files, that's why I set it to 0.
