### PR TITLE
Fixes ctrlp_user_command for git repositories

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -393,7 +393,7 @@
 
         let g:ctrlp_user_command = {
             \ 'types': {
-                \ 1: ['.git', 'cd %s && git ls-files'],
+                \ 1: ['.git', 'cd %s && git ls-files . --cached --exclude-standard --others'],
                 \ 2: ['.hg', 'hg --cwd %s locate -I .'],
             \ },
             \ 'fallback': 'find %s -type f'


### PR DESCRIPTION
The patch I submitted in #245 was incorrect it was missing the changes 
from https://github.com/kien/ctrlp.vim/issues/174 which ensure that 
untracked files will also be included in the search. This fixes that.
