### PR TITLE
Add option to skip window navigation mappings and keep digraph key

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -191,10 +191,16 @@
     endif
 
     " Easier moving in tabs and windows
-    map <C-J> <C-W>j<C-W>_
-    map <C-K> <C-W>k<C-W>_
-    map <C-L> <C-W>l<C-W>_
-    map <C-H> <C-W>h<C-W>_
+    " The lines conflict with the default digraph mapping of <C-K>
+    " If you prefer that functionality, add let g:spf13_no_easyWindows = 1
+    " in your .vimrc.bundles.local file
+
+    if !exists('g:spf13_no_easyWindows')
+        map <C-J> <C-W>j<C-W>_
+        map <C-K> <C-W>k<C-W>_
+        map <C-L> <C-W>l<C-W>_
+        map <C-H> <C-W>h<C-W>_
+    endif
 
     " Wrapped lines goes down/up to next row, rather than next line in file.
     nnoremap j gj


### PR DESCRIPTION
Addresses issue #255 by allowing users to `let g:spf13_no_easyWindows = 1` and disable the `<C-J>` `<C-K>` `<C-L>` and `<C-H>` mappings, thereby not overriding `<C-K>` as the digraph key.
