### PR TITLE
vim-gitgutter highlighting

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -131,6 +131,9 @@
 
     set cursorline                  " Highlight current line
 
+    highlight clear SignColumn      " SignColumn should match background for
+                                    " things like vim-gitgutter
+
     if has('cmdline_info')
         set ruler                   " Show the ruler
         set rulerformat=%30(%=\:b%n%y%m%r%w\ %l,%c%V\ %P%) " A ruler on steroids


### PR DESCRIPTION
Background color of sign column in gitgutter is distracting. Per
airblade's docs adding this command cleans it up
