### PR TITLE
Disable the neosnippet preview candidate window. When enabled, there can...

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -526,6 +526,11 @@
         if has('conceal')
             set conceallevel=2 concealcursor=i
         endif
+
+        " Disable the neosnippet preview candidate window
+        " When enabled, there can be too much visual noise
+        " especially when splits are used.
+        set completeopt-=preview
     " }
 
     " UndoTree {


### PR DESCRIPTION
... be too much visual noise especially when splits are used.
