### PR TITLE
Added the VDebug multi-purpose debugger

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -178,6 +178,11 @@
             Bundle 'jnwhiteh/vim-golang'
         endif
 
+    " VDebug - Multi-purpose debugger
+        if count(g:spf13_bundle_groups, 'debugger')
+            Bundle 'joonty/vdebug'
+        endif
+
     " Misc
         if count(g:spf13_bundle_groups, 'misc')
             Bundle 'tpope/vim-markdown'


### PR DESCRIPTION
VDebug is an amazing multi-language Vim debugger. It is a complete re-write of the Xdebug project with several additions: no error messages, abstracted configuration and code-base, supports multiple languages (PHP, Python, Ruby, Perl, Tcl, JavaScript), the documentation is clean, and the UI is clean and consistent.

See ":help vdebug" for more information.

I applied the following overrides to my .vimrc.bundles.local file.

" Vdebug {
    let g:vdebug_options= {
    \    "port" : 9000,
    \    "server" : '205.189.23.105',
    \    "timeout" : 20,
    \    "on_close" : 'detach',
    \    "ide_key" : '1',
    }

```
" Map the key bindings to Firebug
let g:vdebug_keymap = {
\    "run_to_cursor" : "<F1>",
\    "set_breakpoint" : "<F4>",
\    "run" : "<F5>",
\    "close" : "<F6>",
\    "detach" : "<F7>",
\    "get_context" : "<F8>",
\    "eval_under_cursor" : "<F9>",
\    "step_over" : "<F10>",
\    "step_into" : "<F11>",
\    "step_out" : "<S-F11>",
\}
```

" }
