### PR TITLE
Use vim-snippets instead of snipmate-snippets

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -117,15 +117,15 @@
     " Snippets & AutoComplete
         if count(g:spf13_bundle_groups, 'snipmate')
             Bundle 'garbas/vim-snipmate'
-            Bundle 'honza/snipmate-snippets'
-            " Source support_function.vim to support snipmate-snippets.
-            if filereadable(expand("~/.vim/bundle/snipmate-snippets/snippets/support_functions.vim"))
-                source ~/.vim/bundle/snipmate-snippets/snippets/support_functions.vim
+            Bundle 'honza/vim-snippets'
+            " Source support_function.vim to support vim-snippets.
+            if filereadable(expand("~/.vim/bundle/vim-snippets/snippets/support_functions.vim"))
+                source ~/.vim/bundle/vim-snippets/snippets/support_functions.vim
             endif
         elseif count(g:spf13_bundle_groups, 'neocomplcache')
             Bundle 'Shougo/neocomplcache'
             Bundle 'Shougo/neosnippet'
-            Bundle 'honza/snipmate-snippets'
+            Bundle 'honza/vim-snippets'
         endif
 
     " PHP


### PR DESCRIPTION
As discussed on:
https://github.com/garbas/vim-snipmate/issues/114#issuecomment-15894423

On another note. Spf what plugin is adding these weird characters in the gutter before my line numbers? Thx!

![weird chars](http://i.imgur.com/3sWjemA.png)
