### PR TITLE
Update GitGutter after Gwrite

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -454,6 +454,7 @@
         nnoremap <silent> <leader>gl :Glog<CR>
         nnoremap <silent> <leader>gp :Git push<CR>
         nnoremap <silent> <leader>gw :Gwrite<CR>:GitGutter<CR>
+        nnoremap <silent> <leader>gg :GitGutterToggle<CR>
     "}
 
     " neocomplcache {

--- a/.vimrc
+++ b/.vimrc
@@ -453,7 +453,7 @@
         nnoremap <silent> <leader>gb :Gblame<CR>
         nnoremap <silent> <leader>gl :Glog<CR>
         nnoremap <silent> <leader>gp :Git push<CR>
-        nnoremap <silent> <leader>gw :Gwrite<CR>
+        nnoremap <silent> <leader>gw :Gwrite<CR>:GitGutter<CR>
     "}
 
     " neocomplcache {


### PR DESCRIPTION
GitGutter needs to be updated after `:Gwrite` is called.

I also added `<leader>gg` to toggle g(it)g(utter) visibility. All of the other `<leader>g_` shortcuts are related to fugitive, but I feel that it's best to just put the "git-related" shortcuts together. The `<leader>gg` mnemonic shouldn't conflict with any git commands other than grep, which is probably much less frequently used.
