### PR TITLE
Fix typo in "Removing (disabling) an included plugin" section.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -187,15 +187,15 @@ To add a new bundle
 
 ## Removing (disabling) an included plugin
 
-Create `~/.vimrc.local` if it doesn't already exist.
+Create `~/.vimrc.bundles.local` if it doesn't already exist.
 
 Add the UnBundle command to this line. It takes the same input as the Bundle line, so simply copy the line you want to disable and add 'Un' to the beginning.
 
 For example, disabling the 'AutoClose' and 'scrooloose/syntastic' plugins
 
 ```bash
-    echo UnBundle \'AutoClose\' >> ~/.vimrc.local
-    echo UnBundle \'scrooloose/syntastic\' >> ~/.vimrc.local
+    echo UnBundle \'AutoClose\' >> ~/.vimrc.bundles.local
+    echo UnBundle \'scrooloose/syntastic\' >> ~/.vimrc.bundles.local
 ```
 
 **Remember to run ':BundleClean!' after this to remove the existing directories**


### PR DESCRIPTION
Fixed copy so that it reflects the correct file to add `UnBundle` command to.

Related to #369 
