### PR TITLE
CtrlP doesn't find files on Windows (#381)

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -411,13 +411,24 @@
             \ 'dir':  '\.git$\|\.hg$\|\.svn$',
             \ 'file': '\.exe$\|\.so$\|\.dll$\|\.pyc$' }
 
-        let g:ctrlp_user_command = {
-            \ 'types': {
-                \ 1: ['.git', 'cd %s && git ls-files . --cached --exclude-standard --others'],
-                \ 2: ['.hg', 'hg --cwd %s locate -I .'],
-            \ },
-            \ 'fallback': 'find %s -type f'
-        \ }
+        " On Windows use "dir" as fallback command.
+        if has('win32') || has('win64')
+            let g:ctrlp_user_command = {
+                \ 'types': {
+                    \ 1: ['.git', 'cd %s && git ls-files . --cached --exclude-standard --others'],
+                    \ 2: ['.hg', 'hg --cwd %s locate -I .'],
+                \ },
+                \ 'fallback': 'dir %s /-n /b /s /a-d'
+            \ }
+        else
+            let g:ctrlp_user_command = {
+                \ 'types': {
+                    \ 1: ['.git', 'cd %s && git ls-files . --cached --exclude-standard --others'],
+                    \ 2: ['.hg', 'hg --cwd %s locate -I .'],
+                \ },
+                \ 'fallback': 'find %s -type f'
+            \ }
+        endif
     "}
 
     " TagBar {


### PR DESCRIPTION
On Windows, the fallback command (g:ctrlp_user_command) should be "dir" instead of "find" (#381).
Tested on Windows 7 and Linux.
