### PR TITLE
Set sh as the default shell.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -19,6 +19,7 @@
 
     " Basics {
         set nocompatible        " Must be first line
+        set shell="/bin/sh"
     " }
 
     " Windows Compatible {


### PR DESCRIPTION
Some people use non-POSIX shells. Vim has trouble with non-POSIX login shells. Patching `.vimrc` to fix this is no fun. `vimrc.local` doesn't work because it is loaded too late in the process.
