### PR TITLE
Remove quotes around /bin/sh.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -19,7 +19,7 @@
 
     " Basics {
         set nocompatible        " Must be first line
-        set shell="/bin/sh"
+        set shell=/bin/sh
     " }
 
     " Windows Compatible {


### PR DESCRIPTION
This is a fix for my previous pull request. It should fix things on OSX/Linux, but I doubt a path like that would work on Windows.
