### PR TITLE
Don't set shell to /bin/sh on Windows

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -19,7 +19,9 @@
 
     " Basics {
         set nocompatible        " Must be first line
-        set shell=/bin/sh
+        if !(has('win16') || has('win32') || has('win64'))
+            set shell=/bin/sh
+        endif
     " }
 
     " Windows Compatible {


### PR DESCRIPTION
Don't set shell to `/bin/sh` on Windows. Setting the shell to `sh` on Windows breaks eg. Vundle. Shell should default to  `%comspec%` on Windows.. I'm not sure if there's any help setting it to `cmd.exe` explicitly, so there's no point touching it on Windows.
