### PR TITLE
Added smart case to the ack command for those using ag.

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -50,7 +50,7 @@
             Bundle 'mileszs/ack.vim'
         elseif executable('ag')
             Bundle 'mileszs/ack.vim'
-            let g:ackprg = 'ag --nogroup --nocolor --column'
+            let g:ackprg = 'ag --nogroup --nocolor --column --smart-case'
         endif
 
     " Use local bundles if available {


### PR DESCRIPTION
I don't know if the behavior is the same with Ack as it is for Ag but case sensitivity (by default) is frustrating when you aren't 100% sure of the format of what you are looking for. I added the smart case flag to the ag command. This can be added to the other ack like commands if need be.
