### PR TITLE
Set default encodings on Windows

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -26,6 +26,22 @@
         " across (heterogeneous) systems easier.
         if has('win32') || has('win64')
           set runtimepath=$HOME/.vim,$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,$HOME/.vim/after
+
+          " Be nice and check for multi_byte even if the config requires
+          " multi_byte support most of the time
+          if has("multi_byte")
+            " Windows cmd.exe still uses cp850. If Windows ever moved to
+            " Powershell as the primary terminal, this would be utf-8
+            set termencoding=cp850
+            " Let Vim use utf-8 internally, because many scripts require this
+            set encoding=utf-8
+            setglobal fileencoding=utf-8
+            " Windows has traditionally used cp1252, so it's probably wise to
+            " fallback into cp1252 instead of eg. iso-8859-15.
+            " Newer Windows files might contain utf-8 or utf-16 LE so we might
+            " want to try them first.
+            set fileencodings=ucs-bom,utf-8,utf-16le,cp1252,iso-8859-15
+          endif
         endif
     " }
     "


### PR DESCRIPTION
Default to utf-8 internally on Windows and use cp850 for terminal. Also set some default fileencoding heuristics that are likely to match not only Windows files but also standard encodings of the 2010s. This fixes at least two problems on Windows:
1. The Windows installer currently throws errors, because Python(?) doesn't work as it should without proper encoding.
2. Ticket #340, which had problems with utf-8 listchars working properly unless they were re-set in .vimrc.local with the correct encoding.
