### PR TITLE
Add sparkup for Zen Coding.

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -196,6 +196,9 @@
             Bundle 'amirh/HTML-AutoCloseTag'
             Bundle 'hail2u/vim-css3-syntax'
             Bundle 'tpope/vim-haml'
+            if (has("python") || has("python3")) && !exists('g:spf13_use_old_powerline')
+                Bundle 'rstacruz/sparkup', {'rtp': 'vim/'}
+            endif
         endif
 
     " Ruby


### PR DESCRIPTION
Sparkup's default mappings conflict with our NERDTree mappings. Will fix in later commit. Fixes #392.
