### PR TITLE
Expect j and k to behave consistently in different modes

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -232,8 +232,8 @@
     endif
 
     " Wrapped lines goes down/up to next row, rather than next line in file.
-    nnoremap j gj
-    nnoremap k gk
+    noremap j gj
+    noremap k gk
 
     " The following two lines conflict with moving to top and
     " bottom of the screen


### PR DESCRIPTION
So, at least I expect `j` and `k` to behave consistently in normal, visual, operator and select mode and thus I'd use `noremap` instead of `nnoremap` for `j` and `k`. Was there some reason `nnoremap` was chosen over `noremap`? `noremap` does not affect the insert mode, if you're afraid of that, see `:help map-overview`.
