### PR TITLE
Fixed bundling of Puppet-Syntax-Highlighting.

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -202,7 +202,7 @@
             Bundle 'spf13/vim-preview'
             Bundle 'tpope/vim-cucumber'
             Bundle 'quentindecock/vim-cucumber-align-pipes'
-            Bundle 'Puppet-Syntax-Highlighting'
+            Bundle 'vim-scripts/Puppet-Syntax-Highlighting'
         endif
 
 


### PR DESCRIPTION
Bundle 'Puppet-Syntax-Highlighting' -> Bundle 'vim-scripts/Puppet-Syntax-Highlighting'
