### PR TITLE
Airline: Configure to Look More Like Powerline

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -158,6 +158,9 @@
         set statusline+=\ [%{&ff}/%Y]            " Filetype
         set statusline+=\ [%{getcwd()}]          " Current dir
         set statusline+=%=%-14.(%l,%c%V%)\ %p%%  " Right aligned file nav info
+
+        let g:airline_theme='powerlineish'       " airline users use the powerline theme
+        let g:airline_powerline_fonts=1          " and the powerline fonts
     endif
 
     set backspace=indent,eol,start  " Backspace for dummies

--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -107,6 +107,8 @@
                 Bundle 'Lokaltog/vim-powerline'
             else
                 Bundle 'bling/vim-airline'
+                let g:airline_theme='powerlineish'
+                let g:airline_powerline_fonts=1
             endif
 
             Bundle 'Lokaltog/vim-easymotion'

--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -107,8 +107,6 @@
                 Bundle 'Lokaltog/vim-powerline'
             else
                 Bundle 'bling/vim-airline'
-                let g:airline_theme='powerlineish'
-                let g:airline_powerline_fonts=1
             endif
 
             Bundle 'Lokaltog/vim-easymotion'


### PR DESCRIPTION
I like the speed and lack of dependencies of vim-airline but I prefer the look of powerline. I added a theme "powerlineish" to vim-airline that mimics the colors of classic powerline. This commit enables that theme and enables the use of powerline fonts to get the nice separators.

I wasn't sure if this should go in `.vimrc` in the status line section or in `.vimrc.bundles`. I opted for the latter so the variables are only set if you're actually using that bundle. Additionally I considered adding a configuration variable to enable the powerline fonts but ultimately decided against it.
