### PR TITLE
add multiple-cursors

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -99,6 +99,7 @@
             Bundle 'tpope/vim-surround'
             Bundle 'spf13/vim-autoclose'
             Bundle 'kien/ctrlp.vim'
+            Bundle 'terryma/vim-multiple-cursors'
             Bundle 'vim-scripts/sessionman.vim'
             Bundle 'matchit.zip'
             if (has("python") || has("python3")) && exists('g:spf13_use_powerline') && !exists('g:spf13_use_old_powerline')


### PR DESCRIPTION
this plugin is too awesome to be excluded from any distribution.  the only thing to worry about is that by default it maps `<c-n>`.
