### PR TITLE
Aesthetic fix for current-line gutter highlight

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -140,6 +140,10 @@
 
     highlight clear SignColumn      " SignColumn should match background for
                                     " things like vim-gitgutter
+                                    
+    highlight clear LineNr          " Current line number row will have same background color in relative mode.
+                                    " Things like vim-gitgutter will match LineNr highlight
+    "highlight clear CursorLineNr   " Remove highlight color from current line number
 
     if has('cmdline_info')
         set ruler                   " Show the ruler


### PR DESCRIPTION
Fix for the new relative number with absolute numbering as of Vim [Patch 7.3.1115](ftp://ftp.vim.org/pub/vim/patches/7.3/7.3.1115). The numbers.vim plugin uses the new relative numbering and the `LineNr` highlight was inconsistent (and vim-gitgutter mirrored this inconsistency).

![lineno](https://f.cloud.github.com/assets/1911028/944122/dab165f4-0296-11e3-83ff-44edf83454f9.png)

`highlight clear LineNr` resolves this inconsistency.
