### PR TITLE
Airline: Disabling Powerline Fonts and Updating README

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -164,7 +164,6 @@
         set statusline+=%=%-14.(%l,%c%V%)\ %p%%  " Right aligned file nav info
 
         let g:airline_theme='powerlineish'       " airline users use the powerline theme
-        let g:airline_powerline_fonts=1          " and the powerline fonts
     endif
 
     set backspace=indent,eol,start  " Backspace for dummies

--- a/README.markdown
+++ b/README.markdown
@@ -382,6 +382,14 @@ For example this screen shot demonstrates pressing `,,w`
 
 ![easymotion image][easymotion-img]
 
+## [Airline]
+
+Airline provides a lightweight themable statusline with no external dependencies. By default it uses the symbols `<` and `>` as separators for different statusline sections but can be configured to use the same symbols as [Powerline]. An example with and without powerline symbols is shown here:
+
+![airline image][airline-img]
+
+To enable powerline symbols first install one of the [Powerline Fonts] or patch your favorite font using the provided instructions. Configure your terminal, MacVim, or Gvim to use the desired font. Finally add `let g:airline_powerline_fonts=1` to your `.vimrc.local`.
+
 ## Additional Syntaxes
 
 spf13-vim ships with a few additional syntaxes:
@@ -466,6 +474,9 @@ Here's some tips if you've never used VIM before:
 [Matchit]:http://www.vim.org/scripts/script.php?script_id=39
 [Tabularize]:https://github.com/godlygeek/tabular
 [EasyMotion]:https://github.com/Lokaltog/vim-easymotion
+[Airline]:https://github.com/bling/vim-airline
+[Powerline]:https://github.com/lokaltog/powerline
+[Powerline Fonts]:https://github.com/Lokaltog/powerline-fonts
 
 [spf13-vim-img]:https://i.imgur.com/UKToY.png
 [spf13-vimrc-img]:https://i.imgur.com/kZWj1.png
@@ -475,3 +486,4 @@ Here's some tips if you've never used VIM before:
 [nerdtree-img]:https://i.imgur.com/9xIfu.png
 [phpmanual-img]:https://i.imgur.com/c0GGP.png
 [easymotion-img]:https://i.imgur.com/ZsrVL.png
+[airline-img]:https://i.imgur.com/sU0PG5P.png


### PR DESCRIPTION
Makes the desired changes mentioned in comments of Issue #413.

Before merging there are a couple of items to address:
1. I added the Airline section at the end of the list of plugins. Perhaps it should be sooner so people are more likely to see it? I feel like the config loses some of its pizazz without the powerline symbols enabled.
2. I am hosting an example image on my own imgur account but it feels like it should be on the same account as the other screenshots. If you upload that image and give me the new link I will gladly change the README.
