### PR TITLE
Source optional .vimrc.before

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -15,6 +15,12 @@
 "   You can find me at http://spf13.com
 " }
 
+" Use vimrc before if available {
+    if filereadable(expand("~/.vimrc.before"))
+        source ~/.vimrc.before
+    endif
+" }
+
 " Environment {
 
     " Basics {


### PR DESCRIPTION
Adding an optional `.vimrc.before` file as suggested by @spf13 in Issue #428
