### PR TITLE
Conditionally override airline separators only if powerline fonts are not used

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -746,8 +746,10 @@
 
     " airline {
         let g:airline_theme='powerlineish'      " airline users use the powerline theme
-        let g:airline_left_sep='›'              " Slightly fancier separator, instead of '>'
-        let g:airline_right_sep='‹'             " Slightly fancier separator, instead of '<'
+        if !exists('g:airline_powerline_fonts')
+          let g:airline_left_sep='›'              " Slightly fancier separator, instead of '>'
+          let g:airline_right_sep='‹'             " Slightly fancier separator, instead of '<'
+        endif
     " }
 
     " vim-gitgutter {


### PR DESCRIPTION
The Airline separators were unconditionally overridden. I have conditionally overridden the separators only if the user doesn't use Powerline fonts.

User is expected to specify `g:airline_powerline_fonts=1` in `~/.vimrc.before.local` instead of `~/.vimrc.local`.
