### PR TITLE
Added optionally bundling YouCompleteMe.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -520,6 +520,48 @@
         nnoremap <silent> <leader>ge :Gedit<CR>
         nnoremap <silent> <leader>gg :GitGutterToggle<CR>
     "}
+    
+    " YouCompleteMe {
+        if count(g:spf13_bundle_groups, 'youcompleteme')
+            let g:acp_enableAtStartup = 0
+            let g:ycm_collect_identifiers_from_tags_files = 1
+            let g:UltiSnipsExpandTrigger = '<C-k> <Plug>'
+            let g:UltiSnipsJumpForwardTrigger = '<C-k> <Plug>'
+            "let g:UltiSnipsJumpBackwardTrigger = '<C-l> <Plug>' " not sure
+            "what to set this to to be consistent.
+
+            " <CR>: close popup
+            " <s-CR>: close popup and save indent.
+            inoremap <expr><s-CR> pumvisible() "\<CR>" : "\<CR>"
+            inoremap <expr><CR> pumvisible()  : "\<CR>"
+
+            " Enable omni completion.
+            autocmd FileType css setlocal omnifunc=csscomplete#CompleteCSS
+            autocmd FileType html,markdown setlocal omnifunc=htmlcomplete#CompleteTags
+            autocmd FileType javascript setlocal omnifunc=javascriptcomplete#CompleteJS
+            autocmd FileType python setlocal omnifunc=pythoncomplete#Complete
+            autocmd FileType xml setlocal omnifunc=xmlcomplete#CompleteTags
+            autocmd FileType ruby setlocal omnifunc=rubycomplete#Complete
+            autocmd FileType haskell setlocal omnifunc=necoghc#omnifunc
+
+            " Haskell post write lint and check with ghcmod
+            " $ `cabal install ghcmod` if missing and ensure
+            " ~/.cabal/bin is in your $PATH.
+            if !executable("ghcmod")
+                autocmd BufWritePost *.hs GhcModCheckAndLintAsync
+            endif
+
+            " For snippet_complete marker.
+            if has('conceal')
+                set conceallevel=2 concealcursor=i
+            endif
+
+            " Disable the neosnippet preview candidate window
+            " When enabled, there can be too much visual noise
+            " especially when splits are used.
+            set completeopt-=preview
+        endif
+    " }
 
     " neocomplete {
         if count(g:spf13_bundle_groups, 'neocomplete')

--- a/.vimrc
+++ b/.vimrc
@@ -524,17 +524,15 @@
     " YouCompleteMe {
         if count(g:spf13_bundle_groups, 'youcompleteme')
             let g:acp_enableAtStartup = 0
+
+            " enable completion from tags
             let g:ycm_collect_identifiers_from_tags_files = 1
-            let g:UltiSnipsExpandTrigger = '<C-k> <Plug>'
-            let g:UltiSnipsJumpForwardTrigger = '<C-k> <Plug>'
-            "let g:UltiSnipsJumpBackwardTrigger = '<C-l> <Plug>' " not sure
-            "what to set this to to be consistent.
 
-            " <CR>: close popup
-            " <s-CR>: close popup and save indent.
-            inoremap <expr><s-CR> pumvisible() "\<CR>" : "\<CR>"
-            inoremap <expr><CR> pumvisible()  : "\<CR>"
-
+            " remap Ultisnips for compatibility for YCM
+            let g:UltiSnipsExpandTrigger = '<C-j>'
+            let g:UltiSnipsJumpForwardTrigger = '<C-j>'
+            let g:UltiSnipsJumpBackwardTrigger = '<C-k>'
+            
             " Enable omni completion.
             autocmd FileType css setlocal omnifunc=csscomplete#CompleteCSS
             autocmd FileType html,markdown setlocal omnifunc=htmlcomplete#CompleteTags

--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -151,8 +151,7 @@
             endif
         elseif count(g:spf13_bundle_groups, 'youcompleteme')
             Bundle 'Valloric/YouCompleteMe'
-            Bundle 'Shougo/neosnippet'
-            Bundle 'honza/vim-snippets'
+            Bundle 'SirVer/ultisnips'
         elseif count(g:spf13_bundle_groups, 'neocomplcache')
             Bundle 'Shougo/neocomplcache'
             Bundle 'Shougo/neosnippet'

--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -149,6 +149,10 @@
             if filereadable(expand("~/.vim/bundle/vim-snippets/snippets/support_functions.vim"))
                 source ~/.vim/bundle/vim-snippets/snippets/support_functions.vim
             endif
+        elseif count(g:spf13_bundle_groups, 'youcompleteme')
+            Bundle 'Valloric/YouCompleteMe'
+            Bundle 'Shougo/neosnippet'
+            Bundle 'honza/vim-snippets'
         elseif count(g:spf13_bundle_groups, 'neocomplcache')
             Bundle 'Shougo/neocomplcache'
             Bundle 'Shougo/neosnippet'

--- a/README.markdown
+++ b/README.markdown
@@ -293,6 +293,37 @@ NeoComplCache is an amazing autocomplete plugin with additional support for snip
 
 ![neocomplcache image][autocomplete-img]
 
+## [YouCompleteMe]
+
+[YouCompleteMe](https://github.com/Valloric/YouCompleteMe) is another amazing
+completion engine. It is slightly more involved to set up as it contains a
+binary component that the user needs to compile before it will work. As a
+result of this however it is very fast.
+
+To enable YouCompleteMe add `YouCompleteMe` to your list of groups by
+overriding it in your `.vimrc.bundles.local` like so:
+`let g:spf13_bundle_groups=['general', 'programming', 'misc', 'scala', 'YouCompleteMe']`
+This is just an example. Remember to choose the other groups you want here.
+
+Once you have done this you will need to get Vundle to grab the latest code
+from git. You can do this by calling `:BundleInstall!`. You should see
+YouCompleteMe in the list.
+
+You will now have the code in your bundles directory and can proceed to compile
+the core. Change to the directory it has been downloaded to. If you have a
+vanilla install then `cd ~/.spf13-vim-3/.vim/bundle/YouCompleteMe/` should do the
+trick. You should see a file in this directory called install.sh. There are a
+few options to consider before running the installer:
+
+  * Do you want clang support (if you don't know what this is then you likely don't need it)?
+    * Do you want to link against a local libclang or have the installer download the latest for you?
+  * Do you want support for c# via the omnisharp server?
+
+The plugin is well documented on the site linked above. Be sure to give that a
+read and make sure you understand the options you require.
+
+For java users wanting to use eclim be sure to add `let g:EclimCompletionMethod = 'omnifunc'` to your .vimrc.local.
+
 ## [Syntastic]
 
 Syntastic is a syntax checking plugin that runs buffers through external syntax

--- a/README.markdown
+++ b/README.markdown
@@ -295,32 +295,19 @@ NeoComplCache is an amazing autocomplete plugin with additional support for snip
 
 ## [YouCompleteMe]
 
-[YouCompleteMe](https://github.com/Valloric/YouCompleteMe) is another amazing
-completion engine. It is slightly more involved to set up as it contains a
-binary component that the user needs to compile before it will work. As a
-result of this however it is very fast.
+YouCompleteMe is another amazing completion engine. It is slightly more involved to set up as it contains a binary component that the user needs to compile before it will work. As a result of this however it is very fast.
 
-To enable YouCompleteMe add `YouCompleteMe` to your list of groups by
-overriding it in your `.vimrc.bundles.local` like so:
-`let g:spf13_bundle_groups=['general', 'programming', 'misc', 'scala', 'YouCompleteMe']`
-This is just an example. Remember to choose the other groups you want here.
+To enable YouCompleteMe add `YouCompleteMe` to your list of groups by overriding it in your `.vimrc.bundles.local` like so: `let g:spf13_bundle_groups=['general', 'programming', 'misc', 'scala', 'YouCompleteMe']` This is just an example. Remember to choose the other groups you want here.
 
-Once you have done this you will need to get Vundle to grab the latest code
-from git. You can do this by calling `:BundleInstall!`. You should see
-YouCompleteMe in the list.
+Once you have done this you will need to get Vundle to grab the latest code from git. You can do this by calling `:BundleInstall!`. You should see YouCompleteMe in the list.
 
-You will now have the code in your bundles directory and can proceed to compile
-the core. Change to the directory it has been downloaded to. If you have a
-vanilla install then `cd ~/.spf13-vim-3/.vim/bundle/YouCompleteMe/` should do the
-trick. You should see a file in this directory called install.sh. There are a
-few options to consider before running the installer:
+You will now have the code in your bundles directory and can proceed to compile the core. Change to the directory it has been downloaded to. If you have a vanilla install then `cd ~/.spf13-vim-3/.vim/bundle/YouCompleteMe/` should do the trick. You should see a file in this directory called install.sh. There are a few options to consider before running the installer:
 
   * Do you want clang support (if you don't know what this is then you likely don't need it)?
     * Do you want to link against a local libclang or have the installer download the latest for you?
   * Do you want support for c# via the omnisharp server?
 
-The plugin is well documented on the site linked above. Be sure to give that a
-read and make sure you understand the options you require.
+The plugin is well documented on the site linked above. Be sure to give that a read and make sure you understand the options you require.
 
 For java users wanting to use eclim be sure to add `let g:EclimCompletionMethod = 'omnifunc'` to your .vimrc.local.
 
@@ -517,6 +504,7 @@ Here's some tips if you've never used VIM before:
 [Tagbar]:https://github.com/majutsushi/tagbar
 [Syntastic]:https://github.com/scrooloose/syntastic
 [vim-easymotion]:https://github.com/Lokaltog/vim-easymotion
+[YouCompleteMe]:https://github.com/Valloric/YouCompleteMe
 [Matchit]:http://www.vim.org/scripts/script.php?script_id=39
 [Tabularize]:https://github.com/godlygeek/tabular
 [EasyMotion]:https://github.com/Lokaltog/vim-easymotion


### PR DESCRIPTION
So when I originally started writing this I was going to test for the binary like you suggested however I hit a bit of a catch 22. 

In order for the ycm_core to be available the plugin would have already needed to be bundled for the source to be available for compilation. As such it does not seem legit to check for the ycm_core before issuing the Bundle command or new users with fresh installs would never bundle it (without going out of their way to do it manually the first time to compile the core). 

I also didn't really like the idea of bundling it only to unbundle it straight after should the compiled core not be found. This approach could have left users confused as they might think they are using YouCompleteMe when it is in fact falling back to Neocomplcache or something similar.

At the moment my recommended approach would be to allow users to bundle it in their own .vimrc.bundles and then the onus is on them to then make sure the core is compiled. The plugin itself actually performs checks and tells the user if the core cannot be found. 

If you can think of a better way to do this I'm happy to make changes.

EDIT: I'm not really intending that you merge this straight away. Just wanted to start a discussion about it's implementation.
