### PR TITLE
auto restore cursor to last edit position when open file

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -118,6 +118,24 @@
     " set it to the first line when editing a git commit message
     au FileType gitcommit au! BufEnter COMMIT_EDITMSG call setpos('.', [0, 1, 1, 0])
 
+    " http://vim.wikia.com/wiki/Restore_cursor_to_file_position_in_previous_editing_session
+    " Restore cursor to file position in previous editing session
+    " To disable this, add the following to your .vimrc.before.local file:
+    "   let g:spf13_no_restore_cursor = 1
+    if !exists('g:spf13_no_restore_cursor')
+        function! ResCur()
+            if line("'\"") <= line("$")
+                normal! g`"
+                return 1
+            endif
+        endfunction
+
+        augroup resCur
+            autocmd!
+            autocmd BufWinEnter * call ResCur()
+        augroup END
+    endif
+
     " Setting up the directories {
         set backup                  " Backups are nice ...
         if has('persistent_undo')


### PR DESCRIPTION
Vim will lost cursor position when switch buffer or reopen file, so this hack will make it works like a charm.
