### PR TITLE
Populate .vimrc.before with all spf13 options

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -811,7 +811,7 @@
 
         " To specify a different directory in which to place the vimbackup,
         " vimviews, vimundo, and vimswap files/directories, add the following to
-        " your .vimrc.local file:
+        " your .vimrc.before.local file:
         "   let g:spf13_consolidated_directory = <full path to desired directory>
         "   eg: let g:spf13_consolidated_directory = $HOME . '/.vim/'
         if exists('g:spf13_consolidated_directory')
@@ -836,6 +836,7 @@
             endif
         endfor
     endfunction
+    call InitializeDirectories()
     " }
 
     " Initialize NERDTree as needed {
@@ -855,7 +856,7 @@
     " Strip whitespace {
     function! StripTrailingWhitespace()
         " To disable the stripping of whitespace, add the following to your
-        " .vimrc.local file:
+        " .vimrc.before.local file:
         "   let g:spf13_keep_trailing_whitespace = 1
         if !exists('g:spf13_keep_trailing_whitespace')
             " Preparation: save last search, and cursor position.
@@ -914,8 +915,4 @@
             source ~/.gvimrc.local
         endif
     endif
-" }
-
-" Finish local initializations {
-    call InitializeDirectories()
 " }

--- a/.vimrc.before
+++ b/.vimrc.before
@@ -1,0 +1,51 @@
+" Modeline and Notes {
+" vim: set sw=4 ts=4 sts=4 et tw=78 foldmarker={,} foldlevel=0 foldmethod=marker spell:
+"
+"                    __ _ _____              _
+"         ___ _ __  / _/ |___ /      __   __(_)_ __ ___
+"        / __| '_ \| |_| | |_ \ _____\ \ / /| | '_ ` _ \
+"        \__ \ |_) |  _| |___) |_____|\ V / | | | | | | |
+"        |___/ .__/|_| |_|____/        \_/  |_|_| |_| |_|
+"            |_|
+"
+"   This is the personal .vimrc.before file of Steve Francia.
+"   While much of it is beneficial for general use, I would
+"   recommend picking out the parts you want and understand.
+"
+"   You can find me at http://spf13.com
+" }
+
+" spf13 options {
+
+    " Prevent automatically changing to open file directory
+    "   let g:spf13_no_autochdir = 1
+
+    " Disable views
+    "   let g:spf13_no_views = 1
+
+    " Leader key
+    "   let g:spf13_leader='\'
+
+    " Disable easier moving in tabs and windows
+    "   let g:spf13_no_easyWindows = 1
+
+    " Disable fast tab navigation
+    "   let g:spf13_no_fastTabs
+
+    " Clear search highlighting
+    "   let g:spf13_clear_search_highlight = 1
+
+    " Disable neosnippet expansion
+    "   let g:spf13_no_neosnippet_expand = 1
+
+    " Disable whitespace stripping
+    "   let g:spf13_keep_trailing_whitespace = 1
+
+    " Enable powerline symbols
+    "   let g:airline_powerline_fonts = 1
+
+    " vim files directory
+    "   let g:spf13_consolidated_directory = <full path to desired directory>
+    "   eg: let g:spf13_consolidated_directory = $HOME . '/.vim/'
+
+" }

--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ spf13-vim is a distribution of vim plugins and resources for Vim, Gvim and [MacV
 
 It is a good starting point for anyone intending to use VIM for development running equally well on Windows, Linux, \*nix and Mac.
 
-The distribution is completely customisable using a `~/.vimrc.local`, `~/.vimrc.bundles.local`, and `~/.vimrc.before` Vim RC files.
+The distribution is completely customisable using a `~/.vimrc.local`, `~/.vimrc.bundles.local`, and `~/.vimrc.before.local` Vim RC files.
 
 ![spf13-vim image][spf13-vim-img]
 
@@ -41,7 +41,7 @@ The easiest way to install spf13-vim is to use our [automatic installer](https:/
 *Requires Git 1.7+ and Vim 7.3+*
 
 ```bash
-    
+
     curl https://j.mp/spf13-vim3 -L > spf13-vim.sh && sh spf13-vim.sh
 ```
 
@@ -154,12 +154,14 @@ For example, to override the default color schemes:
 ### Before File
 
 Create a `~/.vimrc.before.local` file to define any customizations
-that get loaded *before* the spf-13 `.vimrc`.
+that get loaded *before* the spf13-vim `.vimrc`.
 
 For example, to prevent autocd into a file directory:
 ```bash
     echo let g:spf13_no_autochdir = 1 >> ~/.vimrc.before.local
 ```
+For a list of available spf13-vim specific customization options, look at the `~/.vimrc.before` file.
+
 
 ### Fork Customization
 
@@ -176,7 +178,7 @@ and `.vimrc.bundles.fork` files in the root of their fork.  The load order for t
 7. `.vimrc.fork` - fork vim configuration
 8. `.vimrc.local` - local user configuration
 
-See `.vimrc.bundles` for specifics on what options can be set to override bundle configuration. See `.vimrc` for specifics
+See `.vimrc.bundles` for specifics on what options can be set to override bundle configuration. See `.vimrc.before` for specifics
 on what options can be overridden. Most vim configuration options should be set in your `.vimrc.fork` file, bundle configuration
 needs to be set in your `.vimrc.bundles.fork` file.
 
@@ -396,11 +398,11 @@ For example this screen shot demonstrates pressing `,,w`
 
 ## [Airline]
 
-Airline provides a lightweight themable statusline with no external dependencies. By default it uses the symbols `<` and `>` as separators for different statusline sections but can be configured to use the same symbols as [Powerline]. An example with and without powerline symbols is shown here:
+Airline provides a lightweight themable statusline with no external dependencies. By default it uses the symbols `‹` and `›` as separators for different statusline sections but can be configured to use the same symbols as [Powerline]. An example with and without powerline symbols is shown here:
 
 ![airline image][airline-img]
 
-To enable powerline symbols first install one of the [Powerline Fonts] or patch your favorite font using the provided instructions. Configure your terminal, MacVim, or Gvim to use the desired font. Finally add `let g:airline_powerline_fonts=1` to your `.vimrc.local`.
+To enable powerline symbols first install one of the [Powerline Fonts] or patch your favorite font using the provided instructions. Configure your terminal, MacVim, or Gvim to use the desired font. Finally add `let g:airline_powerline_fonts=1` to your `.vimrc.before.local`.
 
 ## Additional Syntaxes
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -107,6 +107,7 @@ create_symlinks() {
 
     lnif "$endpath/.vimrc"              "$HOME/.vimrc"
     lnif "$endpath/.vimrc.bundles"      "$HOME/.vimrc.bundles"
+    lnif "$endpath/.vimrc.before"       "$HOME/.vimrc.before"
     lnif "$endpath/.vim"                "$HOME/.vim"
 
     # Useful for fork maintainers
@@ -115,12 +116,17 @@ create_symlinks() {
     if [ -e "$endpath/.vimrc.fork" ]; then
         ln -sf "$endpath/.vimrc.fork" "$HOME/.vimrc.fork"
     elif [ "$fork_maintainer" -eq '1' ]; then
-       touch "$HOME/.vimrc.fork"
-       touch "$HOME/.vimrc.bundles.fork"
+        touch "$HOME/.vimrc.fork"
+        touch "$HOME/.vimrc.bundles.fork"
+        touch "$HOME/.vimrc.before.fork"
     fi
 
     if [ -e "$endpath/.vimrc.bundles.fork" ]; then
         ln -sf "$endpath/.vimrc.bundles.fork" "$HOME/.vimrc.bundles.fork"
+    fi
+
+    if [ -e "$endpath/.vimrc.before.fork" ]; then
+        ln -sf "$endpath/.vimrc.before.fork" "$HOME/.vimrc.before.fork"
     fi
 
     if [ ! -d "$endpath/.vim/bundle" ]; then

--- a/spf13-vim-windows-install.cmd
+++ b/spf13-vim-windows-install.cmd
@@ -18,6 +18,8 @@ call mklink "%HOME%\_vimrc" "%BASE_DIR%\.vimrc"
 call mklink "%HOME%\.vimrc.fork" "%BASE_DIR%\.vimrc.fork"
 call mklink "%HOME%\.vimrc.bundles" "%BASE_DIR%\.vimrc.bundles"
 call mklink "%HOME%\.vimrc.bundles.fork" "%BASE_DIR%\.vimrc.bundles.fork"
+call mklink "%HOME%\.vimrc.before" "%BASE_DIR%\.vimrc.before"
+call mklink "%HOME%\.vimrc.before.fork" "%BASE_DIR%\.vimrc.before.fork"
 call mklink /J "%HOME%\.vim" "%BASE_DIR%\.vim"
 
 IF NOT EXIST "%BASE_DIR%\.vim\bundle" (

--- a/spf13-vim-windows-xp-install.cmd
+++ b/spf13-vim-windows-xp-install.cmd
@@ -27,6 +27,7 @@ call xcopy /s/e/h/y/r/q/i "%BASE_DIR%\.vim" "%HOME%\.vim"
 call copy "%BASE_DIR%\.vimrc" "%HOME%\.vimrc"
 call copy "%BASE_DIR%\.vimrc" "%HOME%\_vimrc"
 call copy "%BASE_DIR%\.vimrc.bundles" "%HOME%\.vimrc.bundles"
+call copy "%BASE_DIR%\.vimrc.before" "%HOME%\.vimrc.before"
 
 @if not exist "%HOME%/.vim/bundle/vundle" call git clone https://github.com/gmarik/vundle.git "%HOME%/.vim/bundle/vundle"
 call vim -u "%BASE_DIR%/.vimrc.bundles" - +BundleInstall! +BundleClean +qall


### PR DESCRIPTION
- .vimrc.before should not be modified (just like any other non-local
  or non-fork config file)
- .vimrc.before contains a list of all options that can be set
- .vimrc.before.local is where these options would actually be set
- support .vimrc.before and .vimrc.before.fork in install scripts
