### PR TITLE
Add thinca/vim-fontzoom

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -791,6 +791,11 @@
         " https://github.com/airblade/vim-gitgutter/issues/106
         let g:gitgutter_realtime = 0
     " }
+    
+    " vim-fontzoom {
+        " vim-fontzoom already includes a few default mappings, add reset
+        silent! nmap <unique> <silent> = :<C-u>Fontzoom!<CR>
+    " }
 
 " }
 

--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -126,6 +126,7 @@
             endif
             Bundle 'airblade/vim-gitgutter'
             Bundle 'tpope/vim-abolish.git'
+            Bundle 'thinca/vim-fontzoom'
         endif
 
     " General Programming


### PR DESCRIPTION
Added [`thinca/vim-fontzoom`](https://github.com/thinca/vim-fontzoom) as currently there seems to be no super easy way to control the font size. Typical use case is increasing the font size in case of a sudden presentation.

[`thinca/vim-fontzoom`](https://github.com/thinca/vim-fontzoom) includes a few default keymappings (`+`, `-`, `ctrl-scroll`), I added equals (`=`) mapped to reset. Vim 7.4 cannot map `ctrl-plus/minus/0` so the obvious mappings are ruled out. Let's hope Vim 8 changes this.

I also evaluated [`drmikehenry/vim-fontsize`](https://github.com/drmikehenry/vim-fontsize), but didn't like the separate font sizing mode. Others were more general font managers and those are overkills in my opinion. [`thinca/vim-fontzoom`](https://github.com/thinca/vim-fontzoom) seemed to be the best out there.

In an ideal situation, the window size of gVim wouldn't change, but I guess we have to live with this limitation.

Tested on Windows 8 x64 with vim 7.4. I guess someone should test this on some Linux distro before merging.
