### PR TITLE
Refactor config sourcing for consistency

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -15,12 +15,6 @@
 "   You can find me at http://spf13.com
 " }
 
-" Use before config {
-    if filereadable(expand("~/.vimrc.before"))
-        source ~/.vimrc.before
-    endif
-" }
-
 " Environment {
 
     " Basics {
@@ -38,14 +32,12 @@
         endif
     " }
 
-    " Setup Bundle Support {
-        " The next three lines ensure that the ~/.vim/bundle/ system works
-        filetype on
-        filetype off
-        set rtp+=~/.vim/bundle/vundle
-        call vundle#rc()
-    " }
+" }
 
+" Use before config if available {
+    if filereadable(expand("~/.vimrc.before"))
+        source ~/.vimrc.before
+    endif
 " }
 
 " Use bundles config {

--- a/.vimrc
+++ b/.vimrc
@@ -806,16 +806,6 @@
 
 " Functions {
 
-    " UnBundle {
-    function! UnBundle(arg, ...)
-      let bundle = vundle#config#init_bundle(a:arg, a:000)
-      call filter(g:bundles, 'v:val["name_spec"] != "' . a:arg . '"')
-    endfunction
-
-    com! -nargs=+         UnBundle
-    \ call UnBundle(<args>)
-    " }
-
     " Initialize directories {
     function! InitializeDirectories()
         let parent = $HOME

--- a/.vimrc
+++ b/.vimrc
@@ -642,8 +642,8 @@
             let g:neocomplcache_max_list = 15
             let g:neocomplcache_force_overwrite_completefunc = 1
 
+            " SuperTab like snippets behavior.
             if !exists('g:spf13_no_neosnippet_expand')
-                " SuperTab like snippets behavior.
                 imap <silent><expr><TAB> neosnippet#expandable() ?
                             \ "\<Plug>(neosnippet_expand_or_jump)" : (pumvisible() ?
                             \ "\<C-e>" : "\<TAB>")

--- a/.vimrc
+++ b/.vimrc
@@ -537,10 +537,12 @@
             let g:neocomplete#force_overwrite_completefunc = 1
 
             " SuperTab like snippets behavior.
-            imap <silent><expr><TAB> neosnippet#expandable() ?
-                        \ "\<Plug>(neosnippet_expand_or_jump)" : (pumvisible() ?
-                        \ "\<C-e>" : "\<TAB>")
-            smap <TAB> <Right><Plug>(neosnippet_jump_or_expand)
+            if !exists('g:spf13_no_neosnippet_expand')
+                imap <silent><expr><TAB> neosnippet#expandable() ?
+                            \ "\<Plug>(neosnippet_expand_or_jump)" : (pumvisible() ?
+                            \ "\<C-e>" : "\<TAB>")
+                smap <TAB> <Right><Plug>(neosnippet_jump_or_expand)
+            endif
 
             " Define dictionary.
             let g:neocomplete#sources#dictionary#dictionaries = {
@@ -565,22 +567,24 @@
                     smap <C-k> <Plug>(neosnippet_expand_or_jump)
                 endif
 
-                inoremap <expr><C-g> neocomplete#undo_completion()
-                inoremap <expr><C-l> neocomplete#complete_common_string()
-                inoremap <expr><CR> neocomplete#complete_common_string()
+                if !exists('g:spf13_no_neocompl_mappings')
+                    inoremap <expr><C-g> neocomplete#undo_completion()
+                    inoremap <expr><C-l> neocomplete#complete_common_string()
+                    inoremap <expr><CR> neocomplete#complete_common_string()
 
-                " <TAB>: completion.
-                inoremap <expr><TAB> pumvisible() ? "\<C-n>" : "\<TAB>"
-                inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<TAB>"
+                    " <TAB>: completion.
+                    inoremap <expr><TAB> pumvisible() ? "\<C-n>" : "\<TAB>"
+                    inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<TAB>"
 
-                " <CR>: close popup
-                " <s-CR>: close popup and save indent.
-                inoremap <expr><s-CR> pumvisible() ? neocomplete#close_popup()"\<CR>" : "\<CR>"
-                inoremap <expr><CR> pumvisible() ? neocomplete#close_popup() : "\<CR>"
+                    " <CR>: close popup
+                    " <s-CR>: close popup and save indent.
+                    inoremap <expr><s-CR> pumvisible() ? neocomplete#close_popup()"\<CR>" : "\<CR>"
+                    inoremap <expr><CR> pumvisible() ? neocomplete#close_popup() : "\<CR>"
 
-                " <C-h>, <BS>: close popup and delete backword char.
-                inoremap <expr><BS> neocomplete#smart_close_popup()."\<C-h>"
-                inoremap <expr><C-y> neocomplete#close_popup()
+                    " <C-h>, <BS>: close popup and delete backword char.
+                    inoremap <expr><BS> neocomplete#smart_close_popup()."\<C-h>"
+                    inoremap <expr><C-y> neocomplete#close_popup()
+                endif
             " }
 
             " Enable omni completion.
@@ -638,11 +642,13 @@
             let g:neocomplcache_max_list = 15
             let g:neocomplcache_force_overwrite_completefunc = 1
 
-            " SuperTab like snippets behavior.
-            imap <silent><expr><TAB> neosnippet#expandable() ?
-                        \ "\<Plug>(neosnippet_expand_or_jump)" : (pumvisible() ?
-                        \ "\<C-e>" : "\<TAB>")
-            smap <TAB> <Right><Plug>(neosnippet_jump_or_expand)
+            if !exists('g:spf13_no_neosnippet_expand')
+                " SuperTab like snippets behavior.
+                imap <silent><expr><TAB> neosnippet#expandable() ?
+                            \ "\<Plug>(neosnippet_expand_or_jump)" : (pumvisible() ?
+                            \ "\<C-e>" : "\<TAB>")
+                smap <TAB> <Right><Plug>(neosnippet_jump_or_expand)
+            endif
 
             " Define dictionary.
             let g:neocomplcache_dictionary_filetype_lists = {
@@ -667,22 +673,24 @@
                     smap <C-k> <Plug>(neosnippet_expand_or_jump)
                 endif
 
-                inoremap <expr><C-g> neocomplcache#undo_completion()
-                inoremap <expr><C-l> neocomplcache#complete_common_string()
-                inoremap <expr><CR> neocomplcache#complete_common_string()
+                if !exists('g:spf13_no_neocompl_mappings')
+                    inoremap <expr><C-g> neocomplcache#undo_completion()
+                    inoremap <expr><C-l> neocomplcache#complete_common_string()
+                    inoremap <expr><CR> neocomplcache#complete_common_string()
 
-                " <TAB>: completion.
-                inoremap <expr><TAB> pumvisible() ? "\<C-n>" : "\<TAB>"
-                inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<TAB>"
+                    " <TAB>: completion.
+                    inoremap <expr><TAB> pumvisible() ? "\<C-n>" : "\<TAB>"
+                    inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<TAB>"
 
-                " <CR>: close popup
-                " <s-CR>: close popup and save indent.
-                inoremap <expr><s-CR> pumvisible() ? neocomplcache#close_popup()"\<CR>" : "\<CR>"
-                inoremap <expr><CR> pumvisible() ? neocomplcache#close_popup() : "\<CR>"
+                    " <CR>: close popup
+                    " <s-CR>: close popup and save indent.
+                    inoremap <expr><s-CR> pumvisible() ? neocomplcache#close_popup()"\<CR>" : "\<CR>"
+                    inoremap <expr><CR> pumvisible() ? neocomplcache#close_popup() : "\<CR>"
 
-                " <C-h>, <BS>: close popup and delete backword char.
-                inoremap <expr><BS> neocomplcache#smart_close_popup()."\<C-h>"
-                inoremap <expr><C-y> neocomplcache#close_popup()
+                    " <C-h>, <BS>: close popup and delete backword char.
+                    inoremap <expr><BS> neocomplcache#smart_close_popup()."\<C-h>"
+                    inoremap <expr><C-y> neocomplcache#close_popup()
+                endif
             " }
 
             " Enable omni completion.

--- a/.vimrc.before
+++ b/.vimrc.before
@@ -40,7 +40,13 @@
     "   let g:spf13_clear_search_highlight = 1
 
     " Disable neosnippet expansion
+    " This maps over <C-k> and does some Supertab
+    " emulation with snippets
     "   let g:spf13_no_neosnippet_expand = 1
+
+    " Disable neocomplete / neocomplcache popup mappings
+    " (e.g. Supertab emulation, snippet jumping)
+    "   let g:spf13_no_neocompl_mappings = 1
 
     " Disable whitespace stripping
     "   let g:spf13_keep_trailing_whitespace = 1

--- a/.vimrc.before
+++ b/.vimrc.before
@@ -21,6 +21,11 @@
 
 " spf13 options {
 
+    " Limit spf13 to only the plugin groups listed here
+    "   let g:spf13_bundle_groups=['general', 'neocomplcache', 'programming',
+    "       \ 'php', 'ruby', 'python', 'go', 'twig', 'javascript', 'haskell',
+    "       \ 'html', 'misc', 'scala']
+
     " Prevent automatically changing to open file directory
     "   let g:spf13_no_autochdir = 1
 

--- a/.vimrc.before
+++ b/.vimrc.before
@@ -63,6 +63,9 @@
     "   let g:spf13_consolidated_directory = <full path to desired directory>
     "   eg: let g:spf13_consolidated_directory = $HOME . '/.vim/'
 
+    " Don't change the color of the indent guides
+    "   let g:indent_guides_auto_colors = 0
+
 " }
 
 " Use fork before if available {

--- a/.vimrc.before
+++ b/.vimrc.before
@@ -12,19 +12,11 @@
 "   While much of it is beneficial for general use, I would
 "   recommend picking out the parts you want and understand.
 "
+"   This file is for options which must be set *before* plugins
+"   are loaded and the main .vimrc config is run. Most of these
+"   are for preventing mappings or commands from being created.
+"
 "   You can find me at http://spf13.com
-" }
-
-" Use local before if available {
-    if filereadable(expand("~/.vimrc.before.local"))
-        source ~/.vimrc.before.local
-    endif
-" }
-
-" Use fork before if available {
-    if filereadable(expand("~/.vimrc.before.fork"))
-        source ~/.vimrc.before.fork
-    endif
 " }
 
 " spf13 options {
@@ -60,4 +52,16 @@
     "   let g:spf13_consolidated_directory = <full path to desired directory>
     "   eg: let g:spf13_consolidated_directory = $HOME . '/.vim/'
 
+" }
+
+" Use fork before if available {
+    if filereadable(expand("~/.vimrc.before.fork"))
+        source ~/.vimrc.before.fork
+    endif
+" }
+
+" Use local before if available {
+    if filereadable(expand("~/.vimrc.before.local"))
+        source ~/.vimrc.before.local
+    endif
 " }

--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -12,6 +12,12 @@
 "   While much of it is beneficial for general use, I would
 "   recommend picking out the parts you want and understand.
 "
+"   This file imports the various plugins of spf13. If you
+"   wish to alter which groups are imported, see vimrc.before.
+"   If you wish to add or remove individual bundles, create
+"   ~/.vimrc.bundles.local and `Bundle` or `UnBundle` as needed
+"   from there.
+"
 "   You can find me at http://spf13.com
 " }
 
@@ -51,6 +57,16 @@
         filetype off
         set rtp+=~/.vim/bundle/vundle
         call vundle#rc()
+    " }
+
+    " Add an UnBundle command {
+    function! UnBundle(arg, ...)
+      let bundle = vundle#config#init_bundle(a:arg, a:000)
+      call filter(g:bundles, 'v:val["name_spec"] != "' . a:arg . '"')
+    endfunction
+
+    com! -nargs=+         UnBundle
+    \ call UnBundle(<args>)
     " }
 
 " }

--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -84,7 +84,7 @@
         endif
     " }
 
-    " In your .vimrc.bundles.local file
+    " In your .vimrc.before.local file
     " list only the plugin groups you will use
     if !exists('g:spf13_bundle_groups')
         let g:spf13_bundle_groups=['general', 'neocomplcache', 'programming', 'php', 'ruby', 'python', 'go', 'twig', 'javascript', 'haskell', 'html', 'misc', 'scala']

--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -243,9 +243,6 @@
 
 " }
 
-" General {
-    " set autowrite                  " automatically write a file when leaving a modified buffer
-    set shortmess+=filmnrxoOtT      " Abbrev. of messages (avoids 'hit enter')
 " Use fork bundles config if available {
     if filereadable(expand("~/.vimrc.bundles.fork"))
         source ~/.vimrc.bundles.fork

--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -72,18 +72,6 @@
         endif
     " }
 
-    " Use local bundles config if available {
-        if filereadable(expand("~/.vimrc.bundles.local"))
-            source ~/.vimrc.bundles.local
-        endif
-    " }
-
-    " Use fork bundles config if available {
-        if filereadable(expand("~/.vimrc.bundles.fork"))
-            source ~/.vimrc.bundles.fork
-        endif
-    " }
-
     " In your .vimrc.before.local file
     " list only the plugin groups you will use
     if !exists('g:spf13_bundle_groups')
@@ -258,5 +246,14 @@
 " General {
     " set autowrite                  " automatically write a file when leaving a modified buffer
     set shortmess+=filmnrxoOtT      " Abbrev. of messages (avoids 'hit enter')
+" Use fork bundles config if available {
+    if filereadable(expand("~/.vimrc.bundles.fork"))
+        source ~/.vimrc.bundles.fork
+    endif
 " }
 
+" Use local bundles config if available {
+    if filereadable(expand("~/.vimrc.bundles.local"))
+        source ~/.vimrc.bundles.local
+    endif
+" }

--- a/config-dependencies.gv
+++ b/config-dependencies.gv
@@ -1,0 +1,22 @@
+digraph G {
+	graph [layout=dot]
+
+// This is just an example for you to use as a template.
+// Edit as you like. Whenever you save a legal graph
+// the layout in the graphviz window will be updated.
+
+	/* vim [href="http://www.vim.org/"] */
+	/* dot [href="http://www.graphviz.org/"] */
+	/* vimdot [href="file:///usr/bin/vimdot"] */
+
+	{_} -> _before
+	{_before} -> _before_fork
+	{_before_fork} -> _before_local
+        {_ _before_local} -> _bundles
+	{_bundles} -> _bundles_fork
+	{_bundles} -> _bundles_local
+	{_bundles_fork} -> _bundles_local
+        {_ _bundles_local} -> _fork
+        {_ _fork} -> _local
+        {_ _local} -> g_local
+}


### PR DESCRIPTION
This PR is just to show what I'm going for here and get some feedback.

I'm using this daily now, but I'm worried it won't be a completely smooth transition, see issue #467.

I made a quick graph to show (roughly) what happens, edges either mean "is imported by" or "is imported after" so the whole thing reads top to bottom.
`vimdot config-dependencies.gv` or `dot -Tpng config-dependencies.gv > img.png`
