### PR TITLE
Remove useless help messages for TagBar and NerdTree

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -429,6 +429,7 @@
         let NERDTreeIgnore=['\.pyc', '\~$', '\.swo$', '\.swp$', '\.git', '\.hg', '\.svn', '\.bzr']
         let NERDTreeChDirMode=0
         let NERDTreeQuitOnOpen=1
+        let NERDTreeMinimalUI=1
         let NERDTreeMouseMode=2
         let NERDTreeShowHidden=1
         let NERDTreeKeepTreeInNewTab=1
@@ -513,6 +514,9 @@
             \ 'ctagsbin'  : 'gotags',
             \ 'ctagsargs' : '-sort -silent'
             \ }
+            
+        " Turn off "press F1 for help" message
+        let g:tagbar_compact=1
     "}
 
     " PythonMode {


### PR DESCRIPTION
Both TagBar and NerdTree use precious screen space to display help messages, this turns n00b mode off.
