### PR TITLE
Need to disable indent guides auto colors.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -748,6 +748,7 @@
             let g:indent_guides_auto_colors = 1
         else
             " For some colorschemes, autocolor will not work (eg: 'desert', 'ir_black')
+            let g:indent_guides_auto_colors = 0
             autocmd VimEnter,Colorscheme * :hi IndentGuidesOdd  guibg=#212121 ctermbg=3
             autocmd VimEnter,Colorscheme * :hi IndentGuidesEven guibg=#404040 ctermbg=4
         endif


### PR DESCRIPTION
 If not explicitly disabled the defined colors are always overridden by auto.
