### PR TITLE
Changed g* wrap relative mappings to revert to standard behaviour under nowrap

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -252,11 +252,19 @@
     noremap k gk
 
     " Same for 0, home, end, etc
-    noremap $ g$
-    noremap <End> g<End>
-    noremap 0 g0
-    noremap <Home> g<Home>
-    noremap ^ g^
+    function! WrapRelativeMotion(key)
+        if &wrap
+            execute "normal! g" . a:key
+        else
+            execute "normal!" a:key
+        endif
+    endfunction
+
+    noremap $ :call WrapRelativeMotion("$")<CR>
+    noremap <End> :call WrapRelativeMotion("$")<CR>
+    noremap 0 :call WrapRelativeMotion("0")<CR>
+    noremap <Home> :call WrapRelativeMotion("0")<CR>
+    noremap ^ :call WrapRelativeMotion("^")<CR>
 
     " The following two lines conflict with moving to top and
     " bottom of the screen

--- a/.vimrc
+++ b/.vimrc
@@ -252,19 +252,32 @@
     noremap k gk
 
     " Same for 0, home, end, etc
-    function! WrapRelativeMotion(key)
+    function! WrapRelativeMotion(key, ...)
+        let vis_sel=""
+        if a:0
+            let vis_sel="gv"
+        endif
         if &wrap
-            execute "normal! g" . a:key
+            execute "normal!" vis_sel . "g" . a:key
         else
-            execute "normal!" a:key
+            execute "normal!" vis_sel . a:key
         endif
     endfunction
 
+    " Map g* keys in Normal, Operator-pending, and Visual+select (over written
+    " below) modes
     noremap $ :call WrapRelativeMotion("$")<CR>
     noremap <End> :call WrapRelativeMotion("$")<CR>
     noremap 0 :call WrapRelativeMotion("0")<CR>
     noremap <Home> :call WrapRelativeMotion("0")<CR>
     noremap ^ :call WrapRelativeMotion("^")<CR>
+    " Over write the Visual+Select mode mappings to ensure correct mode is
+    " passed to WrapRelativeMotion
+    vnoremap $ :<C-U>call WrapRelativeMotion("$", 1)<CR>
+    vnoremap <End> :<C-U>call WrapRelativeMotion("$", 1)<CR>
+    vnoremap 0 :<C-U>call WrapRelativeMotion("0", 1)<CR>
+    vnoremap <Home> :<C-U>call WrapRelativeMotion("0", 1)<CR>
+    vnoremap ^ :<C-U>call WrapRelativeMotion("^", 1)<CR>
 
     " The following two lines conflict with moving to top and
     " bottom of the screen


### PR DESCRIPTION
As discussed in issue #464 the new g\* wrap relative line movement mappings still only move to the first or last column on the SCREEN when nowrap is set, when you would expect them to move relative to the LINE.

added/changed the following

``` vim
    function! WrapRelativeMotion(key)
        if &wrap
            execute "normal! g" . a:key
        else
            execute "normal!" a:key
        endif
    endfunction

    noremap $ :call WrapRelativeMotion("$")<CR>
    noremap <End> :call WrapRelativeMotion("$")<CR>
    noremap 0 :call WrapRelativeMotion("0")<CR>
    noremap <Home> :call WrapRelativeMotion("0")<CR>
    noremap ^ :call WrapRelativeMotion("^")<CR>
```

Please improve if you are unhappy with it, but as far as I can see, it does not break anything or slow down the movement noticeably.
