### PR TITLE
Ack.vim now prefers the silver searcher.

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -61,14 +61,14 @@
         Bundle 'gmarik/vundle'
         Bundle 'MarcWeber/vim-addon-mw-utils'
         Bundle 'tomtom/tlib_vim'
-        if executable('ack-grep')
+        if executable('ag')
+            Bundle 'mileszs/ack.vim'
+            let g:ackprg = 'ag --nogroup --nocolor --column --smart-case'
+        elseif executable('ack-grep')
             let g:ackprg="ack-grep -H --nocolor --nogroup --column"
             Bundle 'mileszs/ack.vim'
         elseif executable('ack')
             Bundle 'mileszs/ack.vim'
-        elseif executable('ag')
-            Bundle 'mileszs/ack.vim'
-            let g:ackprg = 'ag --nogroup --nocolor --column --smart-case'
         endif
     " }
 


### PR DESCRIPTION
Ack.vim will now use the silver searcher first if it is installed. The fallback options remain as they were.
