### PR TITLE
neco-ghc moved from ujihisa to eagletmt

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -205,7 +205,7 @@
             Bundle 'dag/vim2hs'
             Bundle 'Twinside/vim-haskellConceal'
             Bundle 'lukerandall/haskellmode-vim'
-            Bundle 'ujihisa/neco-ghc'
+            Bundle 'eagletmt/neco-ghc'
             Bundle 'eagletmt/ghcmod-vim'
             Bundle 'Shougo/vimproc'
             Bundle 'adinapoli/cumino'


### PR DESCRIPTION
Small change to .vimrc.bundles to reflect that ujihisa no longer maintains neco-ghc and has transferred ownership to eagletmt. Just changed the source of neco-ghc from `ujihisa/neco-ghc` to `eagletmt/neco-ghc`
