### PR TITLE
add gorodinskiy/vim-coloresque to html bundles

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -220,6 +220,7 @@
         if count(g:spf13_bundle_groups, 'html')
             Bundle 'amirh/HTML-AutoCloseTag'
             Bundle 'hail2u/vim-css3-syntax'
+            Bundle 'gorodinskiy/vim-coloresque'
             Bundle 'tpope/vim-haml'
         endif
     " }


### PR DESCRIPTION
As mentioned in [issue #522](https://github.com/spf13/spf13-vim/issues/522).
