### PR TITLE
Change ctrl-e to use nerdtree-tabs instead of nerd tree native

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -455,7 +455,7 @@
     " }
 
     " NerdTree {
-        map <C-e> :NERDTreeToggle<CR>:NERDTreeMirror<CR>
+        map <C-e> <plug>NERDTreeTabsToggle<CR>
         map <leader>e :NERDTreeFind<CR>
         nmap <leader>nt :NERDTreeFind<CR>
 


### PR DESCRIPTION
The original point of this line (which I think came from my config originally) was to do exactly what the nerdtree-tabs thing does; since we're using nerdtree tabs, seems like it makes more sense to make this change.  I think they do basically the same thing, but in case they don't (and to be clean) this uses the recommended way to toggle the nerdtree given by the nerdtree-tabs project.
