### PR TITLE
Added Chocolatey NuGet install instructions for Windows

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -54,13 +54,15 @@ If you have a bash-compatible shell you can run the script directly:
 ## Installing on Windows
 
 On Windows and \*nix [Git] and [Curl] are required. Also, if you haven't already, you'll need to install [Vim].
-The quickest option for all three is to install the dependencies([Git] and [Curl]) and spf13-vim via [Chocolatey]. After running the [Chocolatey] install, execute the following commands on the commandline:
+The quickest option to install all three dependencies ([Git], [Curl], [Vim] and [spf13-vim]) via [spf13.vim package]. After running the [Chocolatey] install, execute the following commands on the _command prompt_:
 
     cinst git
     cinst curl
     cinst spf13.vim
 
-_Note: This will install Vim as well_
+_Note: The spf13.vim package will install Vim also! _
+
+If you want to install [msysgit], [Curl] and [spf13-vim] individually, follow the directions below.
 
 ### Installing dependencies
 
@@ -499,6 +501,7 @@ Here's some tips if you've never used VIM before:
 [Vim]:http://www.vim.org/download.php#pc
 [msysgit]:http://code.google.com/p/msysgit
 [Chocolatey]: http://chocolatey.org/
+[spf13.vim package]: http://chocolatey.org/packages/spf13.vim
 [MacVim]:http://code.google.com/p/macvim/
 [spf13-vim]:https://github.com/spf13/spf13-vim
 [contributors]:https://github.com/spf13/spf13-vim/contributors

--- a/README.markdown
+++ b/README.markdown
@@ -54,6 +54,13 @@ If you have a bash-compatible shell you can run the script directly:
 ## Installing on Windows
 
 On Windows and \*nix [Git] and [Curl] are required. Also, if you haven't already, you'll need to install [Vim].
+The quickest option for all three is to install the dependencies([Git] and [Curl]) and spf13-vim via [Chocolatey]. After running the [Chocolatey] install, execute the following commands on the commandline:
+
+    cinst git
+    cinst curl
+    cinst spf13.vim
+
+_Note: This will install Vim as well_
 
 ### Installing dependencies
 
@@ -491,6 +498,7 @@ Here's some tips if you've never used VIM before:
 [Curl]:http://curl.haxx.se
 [Vim]:http://www.vim.org/download.php#pc
 [msysgit]:http://code.google.com/p/msysgit
+[Chocolatey]: http://chocolatey.org/
 [MacVim]:http://code.google.com/p/macvim/
 [spf13-vim]:https://github.com/spf13/spf13-vim
 [contributors]:https://github.com/spf13/spf13-vim/contributors

--- a/README.markdown
+++ b/README.markdown
@@ -53,7 +53,7 @@ If you have a bash-compatible shell you can run the script directly:
 
 ## Installing on Windows
 
-On Windows and \*nix [Git] and [Curl] are required. Also, if you haven't already, you'll need to install [Vim].
+On Windows and \*nix [Git] and [Curl] are required. Also, if you haven't already, you'll need to install [Vim].  
 The quickest option to install all three dependencies ([Git], [Curl], [Vim] and [spf13-vim]) via [Chocolatey] NuGet and the [spf13.vim package]. After running the [Chocolatey] install, execute the following commands on the _command prompt_:
 
     cinst git
@@ -61,7 +61,7 @@ The quickest option to install all three dependencies ([Git], [Curl], [Vim] and 
     cinst ctags
     cinst spf13.vim
 
-_Note: The [spf13.vim package] will install Vim also! _
+_Note: The spf13.vim package will install Vim also! _
 
 If you want to install [msysgit], [Curl] and [spf13-vim] individually, follow the directions below.
 

--- a/README.markdown
+++ b/README.markdown
@@ -54,13 +54,14 @@ If you have a bash-compatible shell you can run the script directly:
 ## Installing on Windows
 
 On Windows and \*nix [Git] and [Curl] are required. Also, if you haven't already, you'll need to install [Vim].
-The quickest option to install all three dependencies ([Git], [Curl], [Vim] and [spf13-vim]) via [spf13.vim package]. After running the [Chocolatey] install, execute the following commands on the _command prompt_:
+The quickest option to install all three dependencies ([Git], [Curl], [Vim] and [spf13-vim]) via [Chocolatey] NuGet and the [spf13.vim package]. After running the [Chocolatey] install, execute the following commands on the _command prompt_:
 
     cinst git
     cinst curl
+    cinst ctags
     cinst spf13.vim
 
-_Note: The spf13.vim package will install Vim also! _
+_Note: The [spf13.vim package] will install Vim also! _
 
 If you want to install [msysgit], [Curl] and [spf13-vim] individually, follow the directions below.
 


### PR DESCRIPTION
Hi! I added the Windows instructions to the Readme.markdown file for using the [spf13.vim package](http://chocolatey.org/packages/spf13.vim) on the [Chocolatey NuGet](http://chocolatey.org/) site.
