### PR TITLE
Fix clipboard error while running Vim in tmux

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -71,9 +71,9 @@
     scriptencoding utf-8
 
     if has('clipboard')
-        if LINUX()   " On Linux use + register for copy-paste
+        if LINUX()         " On Linux use + register for copy-paste
             set clipboard=unnamedplus
-        else         " On mac and Windows, use * register for copy-paste
+        elseif $TMUX == '' " On mac and Windows, use * register for copy-paste
             set clipboard=unnamed
         endif
     endif


### PR DESCRIPTION
Running Vim whilst in byobu/tmux causes the clipboard not to work, failing with:

`E353: Nothing in register *`

This has already been discussed [here](http://stackoverflow.com/questions/11404800/fix-vim-tmux-yank-paste-on-unnamed-register), the [accepted answer](http://stackoverflow.com/a/11421329/758165) seems to solve it.

There probably should go more testing into this, maybe there are other edge-cases where this might break, but it worked for me both in tmux and directly in the Terminal (running Mac OS X).

Best Regards,
-Pit
