### PR TITLE
Fixing d$ not deleting last character of the line after wrap relative motion code was replaced

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -284,16 +284,17 @@
         endfunction
 
         " Map g* keys in Normal, Operator-pending, and Visual+select
-        nnoremap $ :call WrapRelativeMotion("$")<CR>
-        nnoremap <End> :call WrapRelativeMotion("$")<CR>
-        nnoremap 0 :call WrapRelativeMotion("0")<CR>
-        nnoremap <Home> :call WrapRelativeMotion("0")<CR>
-        nnoremap ^ :call WrapRelativeMotion("^")<CR>
+        noremap $ :call WrapRelativeMotion("$")<CR>
+        noremap <End> :call WrapRelativeMotion("$")<CR>
+        noremap 0 :call WrapRelativeMotion("0")<CR>
+        noremap <Home> :call WrapRelativeMotion("0")<CR>
+        noremap ^ :call WrapRelativeMotion("^")<CR>
+        " Overwrite the operator pending $/<End> mappings from above
+        " to force inclusive motion with :execute normal!
         onoremap $ v:call WrapRelativeMotion("$")<CR>
         onoremap <End> v:call WrapRelativeMotion("$")<CR>
-        onoremap 0 v:call WrapRelativeMotion("0")<CR>
-        onoremap <Home> v:call WrapRelativeMotion("0")<CR>
-        onoremap ^ v:call WrapRelativeMotion("^")<CR>
+        " Overwrite the Visual+select mode mappings from above
+        " to ensure the correct vis_sel flag is passed to function
         vnoremap $ :<C-U>call WrapRelativeMotion("$", 1)<CR>
         vnoremap <End> :<C-U>call WrapRelativeMotion("$", 1)<CR>
         vnoremap 0 :<C-U>call WrapRelativeMotion("0", 1)<CR>

--- a/.vimrc
+++ b/.vimrc
@@ -283,15 +283,17 @@
             endif
         endfunction
 
-        " Map g* keys in Normal, Operator-pending, and Visual+select (over written
-        " below) modes
-        noremap $ :call WrapRelativeMotion("$")<CR>
-        noremap <End> :call WrapRelativeMotion("$")<CR>
-        noremap 0 :call WrapRelativeMotion("0")<CR>
-        noremap <Home> :call WrapRelativeMotion("0")<CR>
-        noremap ^ :call WrapRelativeMotion("^")<CR>
-        " Over write the Visual+Select mode mappings to ensure correct mode is
-        " passed to WrapRelativeMotion
+        " Map g* keys in Normal, Operator-pending, and Visual+select
+        nnoremap $ :call WrapRelativeMotion("$")<CR>
+        nnoremap <End> :call WrapRelativeMotion("$")<CR>
+        nnoremap 0 :call WrapRelativeMotion("0")<CR>
+        nnoremap <Home> :call WrapRelativeMotion("0")<CR>
+        nnoremap ^ :call WrapRelativeMotion("^")<CR>
+        onoremap $ v:call WrapRelativeMotion("$")<CR>
+        onoremap <End> v:call WrapRelativeMotion("$")<CR>
+        onoremap 0 v:call WrapRelativeMotion("0")<CR>
+        onoremap <Home> v:call WrapRelativeMotion("0")<CR>
+        onoremap ^ v:call WrapRelativeMotion("^")<CR>
         vnoremap $ :<C-U>call WrapRelativeMotion("$", 1)<CR>
         vnoremap <End> :<C-U>call WrapRelativeMotion("$", 1)<CR>
         vnoremap 0 :<C-U>call WrapRelativeMotion("0", 1)<CR>

--- a/.vimrc
+++ b/.vimrc
@@ -263,33 +263,41 @@
     noremap j gj
     noremap k gk
 
-    " Same for 0, home, end, etc
-    function! WrapRelativeMotion(key, ...)
-        let vis_sel=""
-        if a:0
-            let vis_sel="gv"
-        endif
-        if &wrap
-            execute "normal!" vis_sel . "g" . a:key
-        else
-            execute "normal!" vis_sel . a:key
-        endif
-    endfunction
+    " End/Start of line motion keys act relative to row/wrap width in the
+    " presence of `:set wrap`, and relative to line for `:set nowrap`.
+    " Default vim behaviour is to act relative to text line in both cases
+    " If you prefer the default behaviour, add the following to your
+    " .vimrc.before.local file:
+    "   let g:spf13_no_wrapRelMotion = 1
+    if !exists('g:spf13_no_wrapRelMotion')
+        " Same for 0, home, end, etc
+        function! WrapRelativeMotion(key, ...)
+            let vis_sel=""
+            if a:0
+                let vis_sel="gv"
+            endif
+            if &wrap
+                execute "normal!" vis_sel . "g" . a:key
+            else
+                execute "normal!" vis_sel . a:key
+            endif
+        endfunction
 
-    " Map g* keys in Normal, Operator-pending, and Visual+select (over written
-    " below) modes
-    noremap $ :call WrapRelativeMotion("$")<CR>
-    noremap <End> :call WrapRelativeMotion("$")<CR>
-    noremap 0 :call WrapRelativeMotion("0")<CR>
-    noremap <Home> :call WrapRelativeMotion("0")<CR>
-    noremap ^ :call WrapRelativeMotion("^")<CR>
-    " Over write the Visual+Select mode mappings to ensure correct mode is
-    " passed to WrapRelativeMotion
-    vnoremap $ :<C-U>call WrapRelativeMotion("$", 1)<CR>
-    vnoremap <End> :<C-U>call WrapRelativeMotion("$", 1)<CR>
-    vnoremap 0 :<C-U>call WrapRelativeMotion("0", 1)<CR>
-    vnoremap <Home> :<C-U>call WrapRelativeMotion("0", 1)<CR>
-    vnoremap ^ :<C-U>call WrapRelativeMotion("^", 1)<CR>
+        " Map g* keys in Normal, Operator-pending, and Visual+select (over written
+        " below) modes
+        noremap $ :call WrapRelativeMotion("$")<CR>
+        noremap <End> :call WrapRelativeMotion("$")<CR>
+        noremap 0 :call WrapRelativeMotion("0")<CR>
+        noremap <Home> :call WrapRelativeMotion("0")<CR>
+        noremap ^ :call WrapRelativeMotion("^")<CR>
+        " Over write the Visual+Select mode mappings to ensure correct mode is
+        " passed to WrapRelativeMotion
+        vnoremap $ :<C-U>call WrapRelativeMotion("$", 1)<CR>
+        vnoremap <End> :<C-U>call WrapRelativeMotion("$", 1)<CR>
+        vnoremap 0 :<C-U>call WrapRelativeMotion("0", 1)<CR>
+        vnoremap <Home> :<C-U>call WrapRelativeMotion("0", 1)<CR>
+        vnoremap ^ :<C-U>call WrapRelativeMotion("^", 1)<CR>
+    endif
 
     " The following two lines conflict with moving to top and
     " bottom of the screen

--- a/.vimrc.before
+++ b/.vimrc.before
@@ -34,6 +34,9 @@
     " Disable easier moving in tabs and windows
     "   let g:spf13_no_easyWindows = 1
 
+    " Disable wrap relative motion for start/end line motions
+    "   let g:spf13_no_wrapRelMotion = 1
+
     " Disable fast tab navigation
     "   let g:spf13_no_fastTabs = 1
 


### PR DESCRIPTION
Fixing issues reported in spf13/spf13-vim#464 re. d$ not deleting last line character after wrap relative motion code was added.
