### PR TITLE
Add Shougo/neosnippet-snippets. Fixes #539.

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -162,10 +162,12 @@
             Bundle 'SirVer/ultisnips'
         elseif count(g:spf13_bundle_groups, 'neocomplcache')
             Bundle 'Shougo/neocomplcache'
+            Bundle 'Shougo/neosnippet-snippets'
             Bundle 'Shougo/neosnippet'
             Bundle 'honza/vim-snippets'
         elseif count(g:spf13_bundle_groups, 'neocomplete')
             Bundle 'Shougo/neocomplete.vim.git'
+            Bundle 'Shougo/neosnippet-snippets'
             Bundle 'Shougo/neosnippet'
             Bundle 'honza/vim-snippets'
         endif

--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -162,13 +162,13 @@
             Bundle 'SirVer/ultisnips'
         elseif count(g:spf13_bundle_groups, 'neocomplcache')
             Bundle 'Shougo/neocomplcache'
-            Bundle 'Shougo/neosnippet-snippets'
             Bundle 'Shougo/neosnippet'
+            Bundle 'Shougo/neosnippet-snippets'
             Bundle 'honza/vim-snippets'
         elseif count(g:spf13_bundle_groups, 'neocomplete')
             Bundle 'Shougo/neocomplete.vim.git'
-            Bundle 'Shougo/neosnippet-snippets'
             Bundle 'Shougo/neosnippet'
+            Bundle 'Shougo/neosnippet-snippets'
             Bundle 'honza/vim-snippets'
         endif
     " }


### PR DESCRIPTION
[Shougo/neosnippet.vim](https://github.com/Shougo/neosnippet.vim) version 4.1 split the repository into two and the other half is now missing. This causes following errors on Mac (#539) and Cygwin at least:

```
neosnippet default snippets cannot be loaded.
You must install neosnippet-snippets or disable runtime snippets.
```

I'm not sure why gVim (on Windows) doesn't warn about this.

This PR adds [Shougo/neosnippet-snippets](https://github.com/Shougo/neosnippet-snippets) as we're already using [the "extra" snippets](https://github.com/honza/vim-snippets), so it makes sense to include the default snippets instead of disabling them. 

More info of the breaking change: https://github.com/Shougo/neosnippet.vim/commit/5dba6a034ed85fc6105f7aa052830cc39ad262bf
