### PR TITLE
Screen program mapping is now opt-in (as it slows down exits from insert back to normal mode)

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -360,12 +360,16 @@
     " http://stackoverflow.com/a/8064607/127816
     vnoremap . :normal .<CR>
 
-    " Fix home and end keybindings for screen, particularly on mac
+    " Fix home and end key bindings for screen, particularly on mac
     " - for some reason this fixes the arrow keys too. huh.
-    map [F $
-    imap [F $
-    map [H g0
-    imap [H g0
+    " - __Note__ that this has been shown to slow down switching from insert
+    "   to normal mode (for users that don't use screen?)
+    if exists('g:spf13_screen_mapping')
+        map [F $
+        imap [F $
+        map [H g0
+        imap [H g0
+    end
 
     " For when you forget to sudo.. Really Write the file.
     cmap w!! w !sudo tee % >/dev/null
@@ -570,7 +574,7 @@
         nnoremap <silent> <leader>gi :Git add -p %<CR>
         nnoremap <silent> <leader>gg :SignifyToggle<CR>
     "}
-    
+
     " YouCompleteMe {
         if count(g:spf13_bundle_groups, 'youcompleteme')
             let g:acp_enableAtStartup = 0
@@ -582,7 +586,7 @@
             let g:UltiSnipsExpandTrigger = '<C-j>'
             let g:UltiSnipsJumpForwardTrigger = '<C-j>'
             let g:UltiSnipsJumpBackwardTrigger = '<C-k>'
-            
+
             " Enable omni completion.
             autocmd FileType css setlocal omnifunc=csscomplete#CompleteCSS
             autocmd FileType html,markdown setlocal omnifunc=htmlcomplete#CompleteTags

--- a/.vimrc
+++ b/.vimrc
@@ -360,17 +360,6 @@
     " http://stackoverflow.com/a/8064607/127816
     vnoremap . :normal .<CR>
 
-    " Fix home and end key bindings for screen, particularly on mac
-    " - for some reason this fixes the arrow keys too. huh.
-    " - __Note__ that this has been shown to slow down switching from insert
-    "   to normal mode (for users that don't use screen?)
-    if exists('g:spf13_screen_mapping')
-        map [F $
-        imap [F $
-        map [H g0
-        imap [H g0
-    end
-
     " For when you forget to sudo.. Really Write the file.
     cmap w!! w !sudo tee % >/dev/null
 

--- a/.vimrc.before
+++ b/.vimrc.before
@@ -86,12 +86,6 @@
     " Require a special keypress to enter multiple cursors mode
     "   let g:multi_cursor_start_key='+'
 
-    " Add mappings for Unix `screen` program.
-    " __Note!__ This has been shown to slow down exiting insert mode back to
-    " normal mode for some users (who don't use screen?)
-    " To enable screen mapping uncomment the following line
-    " let g:spf13_screen_mapping = 1
-
 " }
 
 " Use fork before if available {

--- a/.vimrc.before
+++ b/.vimrc.before
@@ -85,6 +85,13 @@
     "   let g:multi_cursor_quit_key='<Esc>'
     " Require a special keypress to enter multiple cursors mode
     "   let g:multi_cursor_start_key='+'
+
+    " Add mappings for Unix `screen` program.
+    " __Note!__ This has been shown to slow down exiting insert mode back to
+    " normal mode for some users (who don't use screen?)
+    " To enable screen mapping uncomment the following line
+    " let g:spf13_screen_mapping = 1
+
 " }
 
 " Use fork before if available {


### PR DESCRIPTION
To enable screen mapping add `let g:spf13_screen_mapping = 1` in your .vimrc.before
