### PR TITLE
Removed bundle justinmk/vim-sneak

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -130,7 +130,6 @@
             Bundle 'mhinz/vim-signify'
             Bundle 'tpope/vim-abolish.git'
             Bundle 'osyo-manga/vim-over'
-            Bundle 'justinmk/vim-sneak'
         endif
     " }
 


### PR DESCRIPTION
This is a fix for Issue #517.
