### PR TITLE
Update Vundle first

### DIFF
--- a/spf13-vim-windows-install.cmd
+++ b/spf13-vim-windows-install.cmd
@@ -28,6 +28,10 @@ IF NOT EXIST "%APP_DIR%\.vim\bundle" (
 
 IF NOT EXIST "%HOME%/.vim/bundle/vundle" (
 	call git clone https://github.com/gmarik/vundle.git "%HOME%/.vim/bundle/vundle"
+) ELSE (
+  call cd "%HOME%/.vim/bundle/vundle"
+  call git pull
+  call cd %HOME%
 )
 
 call vim -u "%APP_DIR%/.vimrc.bundles" +BundleInstall! +BundleClean +qall


### PR DESCRIPTION
I met some problems with `set shellslash` when updating. It turned out that Vundle has fixed this already, but with that error the old Vundle could not self-update. So I think updating Vundle before everything may be a good idea.
