### PR TITLE
Added bundle honza/vim-snippets for UltiSnips compatability

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -159,6 +159,7 @@
         elseif count(g:spf13_bundle_groups, 'youcompleteme')
             Bundle 'Valloric/YouCompleteMe'
             Bundle 'SirVer/ultisnips'
+            Bundle 'honza/vim-snippets'
         elseif count(g:spf13_bundle_groups, 'neocomplcache')
             Bundle 'Shougo/neocomplcache'
             Bundle 'Shougo/neosnippet'


### PR DESCRIPTION
UltiSnips is apparently now only a snippets engine without snippets. This simply adds the bundle honza/vim-snippets to the bundle list for youcompleteme such that honza's snippets are installed with UltiSnips.
This is the first time I've done a pull request, so if I'm not doing it right please let me know. 
