### PR TITLE
Prevent stopping installation process: disable 'more' option

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -142,7 +142,14 @@ create_symlinks() {
 setup_vundle() {
     system_shell="$SHELL"
     export SHELL='/bin/sh'
-    vim -u "$HOME/.vimrc.bundles" +BundleInstall! +BundleClean +qall
+    
+    vim \
+        -u "$HOME/.vimrc.bundles" \
+        "+set nomore" \
+        +BundleInstall! \
+        +BundleClean \
+        +qall
+    
     export SHELL="$system_shell"
 
     success "$1"


### PR DESCRIPTION
Prevent stopping installation process: disable vim's 'more' option
