### PR TITLE
Removed bundle 'justinmk/vim-sneak'; it messed with default 's' key.

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -130,7 +130,6 @@
             Bundle 'mhinz/vim-signify'
             Bundle 'tpope/vim-abolish.git'
             Bundle 'osyo-manga/vim-over'
-            Bundle 'justinmk/vim-sneak'
             Bundle 'kana/vim-textobj-user'
             Bundle 'kana/vim-textobj-indent'
         endif


### PR DESCRIPTION
This relates to Issue #517 which was fixed in PR #570 but seems to need fixing again.
