### PR TITLE
Add neocomplcache_omni_patterns for Go

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -859,6 +859,7 @@
             let g:neocomplcache_omni_patterns.c = '[^.[:digit:] *\t]\%(\.\|->\)'
             let g:neocomplcache_omni_patterns.cpp = '[^.[:digit:] *\t]\%(\.\|->\)\|\h\w*::'
             let g:neocomplcache_omni_patterns.ruby = '[^. *\t]\.\h\w*\|\h\w*::'
+            let g:neocomplcache_omni_patterns.go = '\h\w*\.\?'
     " }
     " Normal Vim omni-completion {
     " To disable omni complete, add the following to your .vimrc.before.local file:


### PR DESCRIPTION
The default omni pattern is not working for Go and the following pattern is added explicitly:

```
let g:neocomplcache_omni_patterns.go = '\h\w*\.\?'
```
