### PR TITLE
Don't conceal JSON syntax

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -543,6 +543,7 @@
 
     " JSON {
         nmap <leader>jt <Esc>:%!python -m json.tool<CR><Esc>:set filetype=json<CR>
+        let g:vim_json_syntax_conceal = 0 
     " }
 
     " PyMode {


### PR DESCRIPTION
Because hiding characters is a terrible idea. I can't believe the JSON plugin actually does this by default but it does. This is apparently the proper way to disable it. Fixes #375.
