### PR TITLE
Bugfix #320. vimdiff "]c" jump to next diff doesn't work

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -199,7 +199,7 @@
         if count(g:spf13_bundle_groups, 'python')
             " Pick either python-mode or pyflakes & pydoc
             Bundle 'klen/python-mode'
-            Bundle 'python.vim'
+            Bundle 'yssource/python.vim'
             Bundle 'python_match.vim'
             Bundle 'pythoncomplete'
         endif


### PR DESCRIPTION
Bugfix #320. vimdiff "]c" jump to next diff doesn't work #320. Thanks the help from @keelerm84 and @pwolfram
