### PR TITLE
Fixed regex of `NERDTreeIgnore`.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -504,7 +504,7 @@
             nmap <leader>nt :NERDTreeFind<CR>
 
             let NERDTreeShowBookmarks=1
-            let NERDTreeIgnore=['\.pyc', '\~$', '\.swo$', '\.swp$', '\.git', '\.hg', '\.svn', '\.bzr']
+            let NERDTreeIgnore=['\.py[cd]$', '\~$', '\.swo$', '\.swp$', '^\.git$', '^\.hg$', '^\.svn$', '\.bzr$']
             let NERDTreeChDirMode=0
             let NERDTreeQuitOnOpen=1
             let NERDTreeMouseMode=2


### PR DESCRIPTION
NERDTree does'nt show directory which name containing '.git' '.svn' or '.hg'(e.g. 'cupen.github', 'a.svna').
The regx of `NERDTreeIgnore` seem was‘nt working right,I fixed it.
