### PR TITLE
Ensure HOME environmental variable set

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -40,6 +40,12 @@ program_exists() {
     fi
 }
 
+variable_set() {
+    if [ -z "$1" ]; then
+        error "You must have your HOME environmental variable set to continue."
+    fi
+}
+
 ############################ SETUP FUNCTIONS
 lnif() {
     if [ -e "$1" ]; then
@@ -157,6 +163,7 @@ setup_vundle() {
 }
 
 ############################ MAIN()
+variable_set "$HOME"
 program_exists "vim" "To install $app_name you first need to install Vim."
 
 do_backup   "Your old vim stuff has a suffix now and looks like .vim.`date +%Y%m%d%S`" \


### PR DESCRIPTION
When working with puppet (and other setups), it is possible the HOME environmental variable is unset. This
leads to a spf13 bootstrap which does not perform as expected because `$HOME` is empty. This results in files being written to undesirable locations such as `/.spf13-vim-3/.vimrc.bundles` Let's stop the user before they get into this bad state.
