### PR TITLE
replace iunmap <CR> with inoremap <CR> <CR>

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -727,7 +727,7 @@
                     smap <C-k> <Plug>(neosnippet_expand_or_jump)
                 endif
                 if exists('g:spf13_noninvasive_completion')
-                    iunmap <CR>
+                    inoremap <CR> <CR>
                     " <ESC> takes you out of insert mode
                     inoremap <expr> <Esc>   pumvisible() ? "\<C-y>\<Esc>" : "\<Esc>"
                     " <CR> accepts first, then sends the <CR>
@@ -840,7 +840,7 @@
                 imap <C-k> <Plug>(neosnippet_expand_or_jump)
                 smap <C-k> <Plug>(neosnippet_expand_or_jump)
                 if exists('g:spf13_noninvasive_completion')
-                    iunmap <CR>
+                    inoremap <CR> <CR>
                     " <ESC> takes you out of insert mode
                     inoremap <expr> <Esc>   pumvisible() ? "\<C-y>\<Esc>" : "\<Esc>"
                     " <CR> accepts first, then sends the <CR>


### PR DESCRIPTION
If noninvasive completion is set, i get the following error:

Error detected while processing ~/.vimrc:
line  730:
E31: No such mapping
Press ENTER or type command to continue

To avoid this "no such mapping" error, instead of unmapping the commands for <CR> one can simply overwrite it with itself to reset it, which works regardless of wether the mapping existed or not.
