### PR TITLE
Swapped vim-multiple-cursors

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -109,7 +109,7 @@
             Bundle 'spf13/vim-autoclose'
             Bundle 'kien/ctrlp.vim'
             Bundle 'tacahiroy/ctrlp-funky'
-            Bundle 'terryma/vim-multiple-cursors'
+            Bundle 'kristijanhusak/vim-multiple-cursors'
             Bundle 'vim-scripts/sessionman.vim'
             Bundle 'matchit.zip'
             if (has("python") || has("python3")) && exists('g:spf13_use_powerline') && !exists('g:spf13_use_old_powerline')


### PR DESCRIPTION
Swapped out terryma/vim-multiple-cursors for the better supported fork from kristijanhusak/vim-multiple-cursors
