### PR TITLE
Fixed edit shortcuts for paths containing spaces

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -392,7 +392,7 @@
 
     " Some helpers to edit mode
     " http://vimcasts.org/e/14
-    cnoremap %% <C-R>=expand('%:h').'/'<cr>
+    cnoremap %% <C-R>=fnameescape(expand('%:h')).'/'<cr>
     map <leader>ew :e %%
     map <leader>es :sp %%
     map <leader>ev :vsp %%


### PR DESCRIPTION
This is the current implementation on http://vimcasts.org/e/14 
The original one would not work for paths containing spaces or other strange characters.
