### PR TITLE
Removed superfluous TagBar config for golang.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -621,21 +621,6 @@
     " TagBar {
         if isdirectory(expand("~/.vim/bundle/tagbar/"))
             nnoremap <silent> <leader>tt :TagbarToggle<CR>
-
-            " If using go please install the gotags program using the following
-            " go install github.com/jstemmer/gotags
-            " And make sure gotags is in your path
-            let g:tagbar_type_go = {
-                \ 'ctagstype' : 'go',
-                \ 'kinds'     : [  'p:package', 'i:imports:1', 'c:constants', 'v:variables',
-                    \ 't:types',  'n:interfaces', 'w:fields', 'e:embedded', 'm:methods',
-                    \ 'r:constructor', 'f:functions' ],
-                \ 'sro' : '.',
-                \ 'kind2scope' : { 't' : 'ctype', 'n' : 'ntype' },
-                \ 'scope2kind' : { 'ctype' : 't', 'ntype' : 'n' },
-                \ 'ctagsbin'  : 'gotags',
-                \ 'ctagsargs' : '-sort -silent'
-                \ }
         endif
     "}
 


### PR DESCRIPTION
Thanks to 3d430e5c942eac7ea7a7e4d8e548fda1df42d446 which incorporates [fatih/vim-go](https://github.com/fatih/vim-go) (and rightly so!), the prior TagBar global config var that I've removed below should no longer be necessary.

In fact, unless I'm crazy and/or missing something (entirely possible :wink:), [the configurations are exactly the same](https://github.com/fatih/vim-go/blob/master/ftplugin/go/tagbar.vim#L24).

FWIW, I've been using vanilla `fatih/vim-go` + TagBar without the SPF13 `.vimrc` setup and it's been working great.
