### PR TITLE
Fixing bootstrap being destructive

### DIFF
--- a/.vimrc.bundles.default
+++ b/.vimrc.bundles.default
@@ -1,7 +1,8 @@
 " Default Bundles {
+
     " Use before config if available {
-        if filereadable(expand("~/.vimrc.before.fork"))
-            source ~/.vimrc.before.fork
+        if filereadable(expand("~/.vimrc.before"))
+            source ~/.vimrc.before
         endif
     " }
 


### PR DESCRIPTION
The upstream Version of  bootstrap.sh is destructive, as .vimrc.bundles.default only souces.vimrc.before.fork and not .vimrc.before or .vimrc.before.local. Now fixed sourcing .vimrc.before, which then sources the other two by default.
