### PR TITLE
Changed `<Leader>a=` to only align one `=` sign

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -534,8 +534,8 @@
         if isdirectory(expand("~/.vim/bundle/tabular"))
             nmap <Leader>a& :Tabularize /&<CR>
             vmap <Leader>a& :Tabularize /&<CR>
-            nmap <Leader>a= :Tabularize /=<CR>
-            vmap <Leader>a= :Tabularize /=<CR>
+            nmap <Leader>a= :Tabularize /^[^=]*\zs=<CR>
+            vmap <Leader>a= :Tabularize /^[^=]*\zs=<CR>
             nmap <Leader>a=> :Tabularize /=><CR>
             vmap <Leader>a=> :Tabularize /=><CR>
             nmap <Leader>a: :Tabularize /:<CR>


### PR DESCRIPTION
Currently `<Leader>a=` acting on the following:

```
a = b == 3
xyz = u == v
```

produces

```
a   = b = = 3
xyz = u = = v
```

.. which is probably not what the user intended.
Since aligning `=` almost always refers to assignment, it makes sense to only align the first one.
