### PR TITLE
Add numbers.vim.

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -134,6 +134,7 @@
             Bundle 'kana/vim-textobj-user'
             Bundle 'kana/vim-textobj-indent'
             Bundle 'gcmt/wildfire.vim'
+            Bundle 'myusuf3/numbers.vim'
         endif
     " }
 


### PR DESCRIPTION
Numbers.vim should exist since it is referenced in the README and other places.
