### PR TITLE
Change rust.vim to the official one

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -279,7 +279,7 @@
 
     " Misc {
         if count(g:spf13_bundle_groups, 'misc')
-            Bundle 'wting/rust.vim'
+            Bundle 'rust-lang/rust.vim'
             Bundle 'tpope/vim-markdown'
             Bundle 'spf13/vim-preview'
             Bundle 'tpope/vim-cucumber'


### PR DESCRIPTION
Rust vim plugin now has it's dedicated repository so that it'd better to use that. [1]

[1] https://github.com/wting/rust.vim/issues/25
