### PR TITLE
Fix reloading of .vimrc

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -600,6 +600,7 @@
             else
                 let s:ctrlp_fallback = 'find %s -type f'
             endif
+            unlet g:ctrlp_user_command
             let g:ctrlp_user_command = {
                 \ 'types': {
                     \ 1: ['.git', 'cd %s && git ls-files . --cached --exclude-standard --others'],


### PR DESCRIPTION
Issue: If g:ctrlp_user_command have been customized, reloading .vimrc
with :so $MYVIMRC produces "E706: Variable type mismatch for:
g:ctrlp_user_command"
