### PR TITLE
Remove map semicolon to colon

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -372,10 +372,6 @@
     vnoremap H ^
     vnoremap L g_
 
-    "use ; to go to command line
-    nnoremap ; :
-    vnoremap ; :
-
     " Most prefer to toggle search highlighting rather than clear the current
     " search results. To clear search highlighting rather than toggle it on
     " and off, add the following to your .vimrc.before.local file:


### PR DESCRIPTION
This overwrites the original Vim mapping of repeating the last f/F/t/T command.

It should not be by default in spf13-vim. If someone like it, use it in vimrc.local file.
