### PR TITLE
Update project link for msysgit

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,7 +42,7 @@ If you have a bash-compatible shell you can run the script directly:
 
 ## Installing on Windows
 
-On Windows and \*nix [Git] and [Curl] are required. Also, if you haven't done so already, you'll need to install [Vim].  
+On Windows and \*nix [Git] and [Curl] are required. Also, if you haven't done so already, you'll need to install [Vim].
 The quickest option to install all three dependencies ([Git], [Curl], [Vim] and [spf13-vim]) is via [Chocolatey] NuGet. After installing [Chocolatey], execute the following commands on the _command prompt_:
 
     C:\> choco install spf13-vim
@@ -188,9 +188,9 @@ and `.vimrc.bundles.fork` files in the root of their fork.  The load order for t
 
 See `.vimrc.bundles` for specifics on what options can be set to override bundle configuration. See `.vimrc.before` for specifics
 on what options can be overridden. Most vim configuration options should be set in your `.vimrc.fork` file, bundle configuration
-needs to be set in your `.vimrc.bundles.fork` file. 
+needs to be set in your `.vimrc.bundles.fork` file.
 
-You can specify the default bundles for your fork using `.vimrc.before.fork` file. Here is how to create an example `.vimrc.before.fork` file 
+You can specify the default bundles for your fork using `.vimrc.before.fork` file. Here is how to create an example `.vimrc.before.fork` file
 in a fork repo for the default bundles.
 ```bash
     echo let g:spf13_bundle_groups=[\'general\', \'programming\', \'misc\', \'youcompleteme\'] >> .vimrc.before.fork
@@ -511,7 +511,7 @@ Here's some tips if you've never used VIM before:
 [Git]:http://git-scm.com
 [Curl]:http://curl.haxx.se
 [Vim]:http://www.vim.org/download.php#pc
-[msysgit]:http://code.google.com/p/msysgit
+[msysgit]:http://msysgit.github.io
 [Chocolatey]: http://chocolatey.org/
 [spf13-vim package]: https://chocolatey.org/packages/spf13-vim
 [MacVim]:http://code.google.com/p/macvim/


### PR DESCRIPTION
Google Code is closing down soon, a lot of projects are moving from Google Code to GitHub or other repo hosting services. [msysgit](http://msysgit.github.io) is one of them. [Their Google Code page](http://code.google.com/p/msysgit) tell you that they have moved. 

P.S. The trailing whitespaces are stripped automatically by Sublime Text 3. 
