### PR TITLE
updated plugin name

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -232,7 +232,7 @@
             Bundle 'lukerandall/haskellmode-vim'
             Bundle 'eagletmt/neco-ghc'
             Bundle 'eagletmt/ghcmod-vim'
-            Bundle 'Shougo/vimproc'
+            Bundle 'Shougo/vimproc.vim'
             Bundle 'adinapoli/cumino'
             Bundle 'bitc/vim-hdevtools'
         endif


### PR DESCRIPTION
seems that the plugin has changed its name by appending a .vim suffix.
