### PR TITLE
Summary: Fixes #764 - Revert "some useful mappings I use everyday"

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -382,16 +382,6 @@
     nmap <leader>f8 :set foldlevel=8<CR>
     nmap <leader>f9 :set foldlevel=9<CR>
 
-    "UPPERCASE and lowercase conversion
-    nnoremap g^ gUiW
-    nnoremap gv guiW
-
-    "go to first and last char of line
-    nnoremap H ^
-    nnoremap L g_
-    vnoremap H ^
-    vnoremap L g_
-
     " Most prefer to toggle search highlighting rather than clear the current
     " search results. To clear search highlighting rather than toggle it on
     " and off, add the following to your .vimrc.before.local file:


### PR DESCRIPTION
Problem:
The "useful mappings" override existing, arguably _more_ useful
mappings.

Analysis:
Revert the commit.
This commit reverts commit 96678bcd9960684373e18de8f9e51ec0c6d32b3e.

Testing:
Used the old mappings successfully.

Documentation:
No change - the reverted commit did not add/modify docs.
