### PR TITLE
Easily edit spf13-vim configuration

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -285,6 +285,22 @@
         let maplocalleader=g:spf13_localleader
     endif
 
+    " The default mappings for editing and applying the spf13 configuration
+    " are <leader>ev and <leader>sv respectively. Change them to your preference
+    " by adding the following to your .vimrc.before.local file:
+    "   let g:spf13_edit_config_mapping='<leader>ec'
+    "   let g:spf13_apply_config_mapping='<leader>sc'
+    if !exists('g:spf13_edit_config_mapping')
+        let s:spf13_edit_config_mapping = '<leader>ev'
+    else
+        let s:spf13_edit_config_mapping = g:spf13_edit_config_mapping
+    endif
+    if !exists('g:spf13_apply_config_mapping')
+        let s:spf13_apply_config_mapping = '<leader>sv'
+    else
+        let s:spf13_apply_config_mapping = g:spf13_apply_config_mapping
+    endif
+
     " Easier moving in tabs and windows
     " The lines conflict with the default digraph mapping of <C-K>
     " If you prefer that functionality, add the following to your
@@ -1190,8 +1206,8 @@
         execute bufwinnr(".vimrc.local") . "wincmd w"
     endfunction
      
-    noremap <leader>ev :call <SID>EditSpf13Config()<CR>
-    noremap <leader>sv :source ~/.vimrc<CR>
+    execute "noremap " . s:spf13_edit_config_mapping " :call <SID>EditSpf13Config()<CR>"
+    execute "noremap " . s:spf13_apply_config_mapping . " :source ~/.vimrc<CR>"
 " }
 
 " Use fork vimrc if available {

--- a/.vimrc
+++ b/.vimrc
@@ -1150,6 +1150,48 @@
     " e.g. Grep current file for <search_term>: Shell grep -Hn <search_term> %
     " }
 
+    function! s:IsSpf13Fork()
+        let s:is_fork = 0
+        let s:fork_files = ["~/.vimrc.fork", "~/.vimrc.before.fork", "~/.vimrc.bundles.fork"]
+        for fork_file in s:fork_files
+            if filereadable(expand(fork_file, ":p"))
+                let s:is_fork = 1
+                break
+            endif
+        endfor
+        return s:is_fork
+    endfunction
+     
+    function! s:ExpandFilenameAndExecute(command, file)
+        execute a:command . " " . expand(a:file, ":p")
+    endfunction
+     
+    function! s:EditSpf13Config()
+        call <SID>ExpandFilenameAndExecute("tabedit", "~/.vimrc")
+        call <SID>ExpandFilenameAndExecute("vsplit", "~/.vimrc.before")
+        call <SID>ExpandFilenameAndExecute("vsplit", "~/.vimrc.bundles")
+     
+        execute bufwinnr(".vimrc") . "wincmd w"
+        call <SID>ExpandFilenameAndExecute("split", "~/.vimrc.local")
+        wincmd l
+        call <SID>ExpandFilenameAndExecute("split", "~/.vimrc.before.local")
+        wincmd l
+        call <SID>ExpandFilenameAndExecute("split", "~/.vimrc.bundles.local")
+     
+        if <SID>IsSpf13Fork()
+            execute bufwinnr(".vimrc") . "wincmd w"
+            call <SID>ExpandFilenameAndExecute("split", "~/.vimrc.fork")
+            wincmd l
+            call <SID>ExpandFilenameAndExecute("split", "~/.vimrc.before.fork")
+            wincmd l
+            call <SID>ExpandFilenameAndExecute("split", "~/.vimrc.bundles.fork")
+        endif
+     
+        execute bufwinnr(".vimrc.local") . "wincmd w"
+    endfunction
+     
+    noremap <leader>ev :call <SID>EditSpf13Config()<CR>
+    noremap <leader>sv :source ~/.vimrc<CR>
 " }
 
 " Use fork vimrc if available {

--- a/.vimrc.before
+++ b/.vimrc.before
@@ -92,6 +92,10 @@
     " Require a special keypress to enter multiple cursors mode
     "   let g:multi_cursor_start_key='+'
 
+    " Mappings for editing/applying spf13 config
+    "   let g:spf13_edit_config_mapping='<leader>ev'
+    "   let g:spf13_apply_config_mapping='<leader>sv'
+    
 " }
 
 " Use fork before if available {

--- a/README.markdown
+++ b/README.markdown
@@ -202,6 +202,19 @@ file to pull down your fork.
 
 For an example of a fork of spf13-vim that provides customization in this manner see [taxilian's fork](https://github.com/taxilian/spf13-vim).
 
+### Easily Editing Your Configuration
+
+`<Leader>ev` opens a new tab containing the .vimrc configuration files listed above. This makes it easier to get an overview of your
+configuration and make customizations.
+
+`<Leader>sv` sources the .vimrc file, instantly applying your customizations to the currently running vim instance.
+
+These two mappings can themselves be customized by setting the following in .vimrc.before.local:
+```bash
+let g:spf13_edit_config_mapping='<Leader>ev'
+let g:spf13_apply_config_mapping='<Leader>sv'
+```
+
 # Plugins
 
 spf13-vim contains a curated set of popular vim plugins, colors, snippets and syntaxes. Great care has been made to ensure that these plugins play well together and have optimal configuration.


### PR DESCRIPTION
The spf13-vim config is spread across multiple .vimrc files and it can be arduous to track down the location of a particular setting if you want to customize your own instance.
## Viewing / Editing .vimrc files

This pull request introduces a new function EditSpf13Config() that opens a new tab containing the following windows:
- .vimrc
- .vimrc.before
- .vimrc.bundles
- .vimrc.local
- .vimrc.before.local
- .vimrc.bundles.local

The following .fork files are also opened if any are detected:
- .vimrc.fork
- .vimrc.before.fork
- .vimrc.bundles.fork

This makes it much simpler to get an overview of and make changes to your spf13-vim configuration.
## Sourcing .vimrc

Additionally, a convenience mapping is introduced that applies the configuration to the currently running vim instance so you can make changes and apply them straight away.
## Mappings

The default mappings (as suggested by Steve Losh @sjl in [Learn Vimscript the Hard Way](http://learnvimscriptthehardway.stevelosh.com/chapters/07.html)) are:
- `<Leader>ev` - "_e_dit ._v_imrc" - open .vimrc files for editing
- `<Leader>sv` - "_s_ource ._v_imrc" - apply .vimrc configuration

These mappings are configurable by setting the following variables in .vimrc.before.local

``` bash
let g:spf13_edit_config_mapping='<leader>ev'
let g:spf13_apply_config_mapping='<leader>sv'
```
