### PR TITLE
Remove .vim directory recursively

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -13,6 +13,6 @@ die() {
 
 rm $HOME/.vimrc
 rm $HOME/.vimrc.bundles
-rm $HOME/.vim
+rm -rf $HOME/.vim
 
 rm -rf $app_dir


### PR DESCRIPTION
`~/.vim` is a directory, will not be removed without `-rf` parameters. Thanks!
