### PR TITLE
Added Bundle 'powerline/fonts'

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -119,6 +119,7 @@
             else
                 Bundle 'bling/vim-airline'
             endif
+            Bundle 'powerline/fonts'
             Bundle 'bling/vim-bufferline'
             Bundle 'Lokaltog/vim-easymotion'
             Bundle 'jistr/vim-nerdtree-tabs'


### PR DESCRIPTION
Added Bundle 'powerline/fonts' since powerline, vim-powerline, & vim-airline won't really be usefull if they don't actually have fonts that make them look nice.
