### PR TITLE
Silently restore cursor.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -143,7 +143,7 @@
     if !exists('g:spf13_no_restore_cursor')
         function! ResCur()
             if line("'\"") <= line("$")
-                normal! g`"
+                silent! normal! g`"
                 return 1
             endif
         endfunction


### PR DESCRIPTION
I sometimes got "Mark not set" error when opening netrw window for a directory.

![vim_error](https://cloud.githubusercontent.com/assets/1246611/10117203/476fab8a-6481-11e5-850c-b591375c8ff4.png)

This ensure that error goes silently when mark is not set.
