### PR TITLE
Update location of vim-easymotion.

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -121,7 +121,7 @@
             endif
             Bundle 'powerline/fonts'
             Bundle 'bling/vim-bufferline'
-            Bundle 'Lokaltog/vim-easymotion'
+            Bundle 'easymotion/vim-easymotion'
             Bundle 'jistr/vim-nerdtree-tabs'
             Bundle 'flazz/vim-colorschemes'
             Bundle 'mbbill/undotree'


### PR DESCRIPTION
vim-easymotion is now in the easymotion github org.
The previous location redirected to the new one, but
we might as well update the reference to the new location.
