### PR TITLE
use pymode even for python3

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -603,7 +603,7 @@
 
     " PyMode {
         " Disable if python support not present
-        if !has('python')
+        if !has('python') && !has('python3')
             let g:pymode = 0
         endif
 


### PR DESCRIPTION
pymode works for python 3 (https://github.com/klen/python-mode/issues/197).  So far, this update (allowing it when python3 is present) seems to work fine for me.
