### PR TITLE
Switch back to terryma's version of vim-multiple-cursors

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -109,7 +109,7 @@
             Bundle 'jiangmiao/auto-pairs'
             Bundle 'ctrlpvim/ctrlp.vim'
             Bundle 'tacahiroy/ctrlp-funky'
-            Bundle 'kristijanhusak/vim-multiple-cursors'
+            Bundle 'terryma/vim-multiple-cursors'
             Bundle 'vim-scripts/sessionman.vim'
             Bundle 'matchit.zip'
             if (has("python") || has("python3")) && exists('g:spf13_use_powerline') && !exists('g:spf13_use_old_powerline')


### PR DESCRIPTION
Terryma's repository is the one being maintained now.
