### PR TITLE
remove 'luochen1990/rainbow' plugin to fix "magic" syntax highlight.

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -158,7 +158,6 @@
             Bundle 'scrooloose/nerdcommenter'
             Bundle 'tpope/vim-commentary'
             Bundle 'godlygeek/tabular'
-            Bundle 'luochen1990/rainbow'
             if executable('ctags')
                 Bundle 'majutsushi/tagbar'
             endif


### PR DESCRIPTION
Fix #875 
