### PR TITLE
Update documentation and scripts to utilize plugin directives instead of deprecated bundle

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -52,7 +52,7 @@
         endif
     " }
 
-    " Setup Bundle Support {
+    " Setup Plugin Support {
         " The next three lines ensure that the ~/.vim/bundle/ system works
         filetype off
         set rtp+=~/.vim/bundle/vundle
@@ -71,20 +71,20 @@
 
 " }
 
-" Bundles {
+" Plugins {
 
     " Deps {
-        Bundle 'gmarik/vundle'
-        Bundle 'MarcWeber/vim-addon-mw-utils'
-        Bundle 'tomtom/tlib_vim'
+        Plugin 'gmarik/vundle'
+        Plugin 'MarcWeber/vim-addon-mw-utils'
+        Plugin 'tomtom/tlib_vim'
         if executable('ag')
-            Bundle 'mileszs/ack.vim'
+            Plugin 'mileszs/ack.vim'
             let g:ackprg = 'ag --nogroup --nocolor --column --smart-case'
         elseif executable('ack-grep')
             let g:ackprg="ack-grep -H --nocolor --nogroup --column"
-            Bundle 'mileszs/ack.vim'
+            Plugin 'mileszs/ack.vim'
         elseif executable('ack')
-            Bundle 'mileszs/ack.vim'
+            Plugin 'mileszs/ack.vim'
         endif
     " }
 
@@ -101,159 +101,159 @@
 
     " General {
         if count(g:spf13_bundle_groups, 'general')
-            Bundle 'scrooloose/nerdtree'
-            Bundle 'altercation/vim-colors-solarized'
-            Bundle 'spf13/vim-colors'
-            Bundle 'tpope/vim-surround'
-            Bundle 'tpope/vim-repeat'
-            Bundle 'rhysd/conflict-marker.vim'
-            Bundle 'jiangmiao/auto-pairs'
-            Bundle 'ctrlpvim/ctrlp.vim'
-            Bundle 'tacahiroy/ctrlp-funky'
-            Bundle 'terryma/vim-multiple-cursors'
-            Bundle 'vim-scripts/sessionman.vim'
-            Bundle 'matchit.zip'
+            Plugin 'scrooloose/nerdtree'
+            Plugin 'altercation/vim-colors-solarized'
+            Plugin 'spf13/vim-colors'
+            Plugin 'tpope/vim-surround'
+            Plugin 'tpope/vim-repeat'
+            Plugin 'rhysd/conflict-marker.vim'
+            Plugin 'jiangmiao/auto-pairs'
+            Plugin 'ctrlpvim/ctrlp.vim'
+            Plugin 'tacahiroy/ctrlp-funky'
+            Plugin 'terryma/vim-multiple-cursors'
+            Plugin 'vim-scripts/sessionman.vim'
+            Plugin 'matchit.zip'
             if (has("python") || has("python3")) && exists('g:spf13_use_powerline') && !exists('g:spf13_use_old_powerline')
-                Bundle 'Lokaltog/powerline', {'rtp':'/powerline/bindings/vim'}
+                Plugin 'Lokaltog/powerline', {'rtp':'/powerline/bindings/vim'}
             elseif exists('g:spf13_use_powerline') && exists('g:spf13_use_old_powerline')
-                Bundle 'Lokaltog/vim-powerline'
+                Plugin 'Lokaltog/vim-powerline'
             else
-                Bundle 'bling/vim-airline'
+                Plugin 'bling/vim-airline'
             endif
-            Bundle 'powerline/fonts'
-            Bundle 'bling/vim-bufferline'
-            Bundle 'easymotion/vim-easymotion'
-            Bundle 'jistr/vim-nerdtree-tabs'
-            Bundle 'flazz/vim-colorschemes'
-            Bundle 'mbbill/undotree'
-            Bundle 'nathanaelkane/vim-indent-guides'
+            Plugin 'powerline/fonts'
+            Plugin 'bling/vim-bufferline'
+            Plugin 'easymotion/vim-easymotion'
+            Plugin 'jistr/vim-nerdtree-tabs'
+            Plugin 'flazz/vim-colorschemes'
+            Plugin 'mbbill/undotree'
+            Plugin 'nathanaelkane/vim-indent-guides'
             if !exists('g:spf13_no_views')
-                Bundle 'vim-scripts/restore_view.vim'
+                Plugin 'vim-scripts/restore_view.vim'
             endif
-            Bundle 'mhinz/vim-signify'
-            Bundle 'tpope/vim-abolish.git'
-            Bundle 'osyo-manga/vim-over'
-            Bundle 'kana/vim-textobj-user'
-            Bundle 'kana/vim-textobj-indent'
-            Bundle 'gcmt/wildfire.vim'
+            Plugin 'mhinz/vim-signify'
+            Plugin 'tpope/vim-abolish.git'
+            Plugin 'osyo-manga/vim-over'
+            Plugin 'kana/vim-textobj-user'
+            Plugin 'kana/vim-textobj-indent'
+            Plugin 'gcmt/wildfire.vim'
         endif
     " }
 
     " Writing {
         if count(g:spf13_bundle_groups, 'writing')
-            Bundle 'reedes/vim-litecorrect'
-            Bundle 'reedes/vim-textobj-sentence'
-            Bundle 'reedes/vim-textobj-quote'
-            Bundle 'reedes/vim-wordy'
+            Plugin 'reedes/vim-litecorrect'
+            Plugin 'reedes/vim-textobj-sentence'
+            Plugin 'reedes/vim-textobj-quote'
+            Plugin 'reedes/vim-wordy'
         endif
     " }
 
     " General Programming {
         if count(g:spf13_bundle_groups, 'programming')
             " Pick one of the checksyntax, jslint, or syntastic
-            Bundle 'scrooloose/syntastic'
-            Bundle 'tpope/vim-fugitive'
-            Bundle 'mattn/webapi-vim'
-            Bundle 'mattn/gist-vim'
-            Bundle 'scrooloose/nerdcommenter'
-            Bundle 'tpope/vim-commentary'
-            Bundle 'godlygeek/tabular'
-            Bundle 'luochen1990/rainbow'
+            Plugin 'scrooloose/syntastic'
+            Plugin 'tpope/vim-fugitive'
+            Plugin 'mattn/webapi-vim'
+            Plugin 'mattn/gist-vim'
+            Plugin 'scrooloose/nerdcommenter'
+            Plugin 'tpope/vim-commentary'
+            Plugin 'godlygeek/tabular'
+            Plugin 'luochen1990/rainbow'
             if executable('ctags')
-                Bundle 'majutsushi/tagbar'
+                Plugin 'majutsushi/tagbar'
             endif
         endif
     " }
 
     " Snippets & AutoComplete {
         if count(g:spf13_bundle_groups, 'snipmate')
-            Bundle 'garbas/vim-snipmate'
-            Bundle 'honza/vim-snippets'
+            Plugin 'garbas/vim-snipmate'
+            Plugin 'honza/vim-snippets'
             " Source support_function.vim to support vim-snippets.
             if filereadable(expand("~/.vim/bundle/vim-snippets/snippets/support_functions.vim"))
                 source ~/.vim/bundle/vim-snippets/snippets/support_functions.vim
             endif
         elseif count(g:spf13_bundle_groups, 'youcompleteme')
-            Bundle 'Valloric/YouCompleteMe'
-            Bundle 'SirVer/ultisnips'
-            Bundle 'honza/vim-snippets'
+            Plugin 'Valloric/YouCompleteMe'
+            Plugin 'SirVer/ultisnips'
+            Plugin 'honza/vim-snippets'
         elseif count(g:spf13_bundle_groups, 'neocomplcache')
-            Bundle 'Shougo/neocomplcache'
-            Bundle 'Shougo/neosnippet'
-            Bundle 'Shougo/neosnippet-snippets'
-            Bundle 'honza/vim-snippets'
+            Plugin 'Shougo/neocomplcache'
+            Plugin 'Shougo/neosnippet'
+            Plugin 'Shougo/neosnippet-snippets'
+            Plugin 'honza/vim-snippets'
         elseif count(g:spf13_bundle_groups, 'neocomplete')
-            Bundle 'Shougo/neocomplete.vim.git'
-            Bundle 'Shougo/neosnippet'
-            Bundle 'Shougo/neosnippet-snippets'
-            Bundle 'honza/vim-snippets'
+            Plugin 'Shougo/neocomplete.vim.git'
+            Plugin 'Shougo/neosnippet'
+            Plugin 'Shougo/neosnippet-snippets'
+            Plugin 'honza/vim-snippets'
         endif
     " }
 
     " PHP {
         if count(g:spf13_bundle_groups, 'php')
-            Bundle 'spf13/PIV'
-            Bundle 'arnaud-lb/vim-php-namespace'
-            Bundle 'beyondwords/vim-twig'
+            Plugin 'spf13/PIV'
+            Plugin 'arnaud-lb/vim-php-namespace'
+            Plugin 'beyondwords/vim-twig'
         endif
     " }
 
     " Python {
         if count(g:spf13_bundle_groups, 'python')
             " Pick either python-mode or pyflakes & pydoc
-            Bundle 'klen/python-mode'
-            Bundle 'yssource/python.vim'
-            Bundle 'python_match.vim'
-            Bundle 'pythoncomplete'
+            Plugin 'klen/python-mode'
+            Plugin 'yssource/python.vim'
+            Plugin 'python_match.vim'
+            Plugin 'pythoncomplete'
         endif
     " }
 
     " Javascript {
         if count(g:spf13_bundle_groups, 'javascript')
-            Bundle 'elzr/vim-json'
-            Bundle 'groenewege/vim-less'
-            Bundle 'pangloss/vim-javascript'
-            Bundle 'briancollins/vim-jst'
-            Bundle 'kchmck/vim-coffee-script'
+            Plugin 'elzr/vim-json'
+            Plugin 'groenewege/vim-less'
+            Plugin 'pangloss/vim-javascript'
+            Plugin 'briancollins/vim-jst'
+            Plugin 'kchmck/vim-coffee-script'
         endif
     " }
 
     " Scala {
         if count(g:spf13_bundle_groups, 'scala')
-            Bundle 'derekwyatt/vim-scala'
-            Bundle 'derekwyatt/vim-sbt'
-            Bundle 'xptemplate'
+            Plugin 'derekwyatt/vim-scala'
+            Plugin 'derekwyatt/vim-sbt'
+            Plugin 'xptemplate'
         endif
     " }
 
     " Haskell {
         if count(g:spf13_bundle_groups, 'haskell')
-            Bundle 'travitch/hasksyn'
-            Bundle 'dag/vim2hs'
-            Bundle 'Twinside/vim-haskellConceal'
-            Bundle 'Twinside/vim-haskellFold'
-            Bundle 'lukerandall/haskellmode-vim'
-            Bundle 'eagletmt/neco-ghc'
-            Bundle 'eagletmt/ghcmod-vim'
-            Bundle 'Shougo/vimproc.vim'
-            Bundle 'adinapoli/cumino'
-            Bundle 'bitc/vim-hdevtools'
+            Plugin 'travitch/hasksyn'
+            Plugin 'dag/vim2hs'
+            Plugin 'Twinside/vim-haskellConceal'
+            Plugin 'Twinside/vim-haskellFold'
+            Plugin 'lukerandall/haskellmode-vim'
+            Plugin 'eagletmt/neco-ghc'
+            Plugin 'eagletmt/ghcmod-vim'
+            Plugin 'Shougo/vimproc.vim'
+            Plugin 'adinapoli/cumino'
+            Plugin 'bitc/vim-hdevtools'
         endif
     " }
 
     " HTML {
         if count(g:spf13_bundle_groups, 'html')
-            Bundle 'amirh/HTML-AutoCloseTag'
-            Bundle 'hail2u/vim-css3-syntax'
-            Bundle 'gorodinskiy/vim-coloresque'
-            Bundle 'tpope/vim-haml'
-            Bundle 'mattn/emmet-vim'
+            Plugin 'amirh/HTML-AutoCloseTag'
+            Plugin 'hail2u/vim-css3-syntax'
+            Plugin 'gorodinskiy/vim-coloresque'
+            Plugin 'tpope/vim-haml'
+            Plugin 'mattn/emmet-vim'
         endif
     " }
 
     " Ruby {
         if count(g:spf13_bundle_groups, 'ruby')
-            Bundle 'tpope/vim-rails'
+            Plugin 'tpope/vim-rails'
             let g:rubycomplete_buffer_loading = 1
             "let g:rubycomplete_classes_in_global = 1
             "let g:rubycomplete_rails = 1
@@ -262,34 +262,34 @@
 
     " Puppet {
         if count(g:spf13_bundle_groups, 'puppet')
-            Bundle 'rodjek/vim-puppet'
+            Plugin 'rodjek/vim-puppet'
         endif
     " }
 
     " Go Lang {
         if count(g:spf13_bundle_groups, 'go')
-            "Bundle 'Blackrush/vim-gocode'
-            Bundle 'fatih/vim-go'
+            "Plugin 'Blackrush/vim-gocode'
+            Plugin 'fatih/vim-go'
         endif
     " }
 
     " Elixir {
         if count(g:spf13_bundle_groups, 'elixir')
-            Bundle 'elixir-lang/vim-elixir'
-            Bundle 'carlosgaldino/elixir-snippets'
-            Bundle 'mattreduce/vim-mix'
+            Plugin 'elixir-lang/vim-elixir'
+            Plugin 'carlosgaldino/elixir-snippets'
+            Plugin 'mattreduce/vim-mix'
         endif
     " }
 
     " Misc {
         if count(g:spf13_bundle_groups, 'misc')
-            Bundle 'rust-lang/rust.vim'
-            Bundle 'tpope/vim-markdown'
-            Bundle 'spf13/vim-preview'
-            Bundle 'tpope/vim-cucumber'
-            Bundle 'cespare/vim-toml'
-            Bundle 'quentindecock/vim-cucumber-align-pipes'
-            Bundle 'saltstack/salt-vim'
+            Plugin 'rust-lang/rust.vim'
+            Plugin 'tpope/vim-markdown'
+            Plugin 'spf13/vim-preview'
+            Plugin 'tpope/vim-cucumber'
+            Plugin 'cespare/vim-toml'
+            Plugin 'quentindecock/vim-cucumber-align-pipes'
+            Plugin 'saltstack/salt-vim'
         endif
     " }
 

--- a/README.markdown
+++ b/README.markdown
@@ -121,7 +121,7 @@ Alternatively you can manually perform the following steps. If anything has chan
 ```bash
     cd $HOME/to/spf13-vim/
     git pull
-    vim +BundleInstall! +BundleClean +q
+    vim +PluginInstall! +PluginClean +qa
 ```
 
 ### Fork me on GitHub
@@ -223,25 +223,25 @@ spf13-vim contains a curated set of popular vim plugins, colors, snippets and sy
 
 ## Adding new plugins
 
-Create `~/.vimrc.bundles.local` for any additional bundles.
+Create `~/.vimrc.bundles.local` for any additional plugins.
 
-To add a new bundle, just add one line for each bundle you want to install. The line should start with the word "Bundle" followed by a string of either the vim.org project name or the githubusername/githubprojectname. For example, the github project [spf13/vim-colors](https://github.com/spf13/vim-colors) can be added with the following command
+To add a new plugin, just add one line for each plugin you want to install. The line should start with the word "Plugin" followed by a string of either the vim.org project name or the githubusername/githubprojectname. For example, the github project [spf13/vim-colors](https://github.com/spf13/vim-colors) can be added with the following command
 
 ```bash
-    echo Bundle \'spf13/vim-colors\' >> ~/.vimrc.bundles.local
+    echo Plugin \'spf13/vim-colors\' >> ~/.vimrc.bundles.local
 ```
 
 Once new plugins are added, they have to be installed.
 
 ```bash
-    vim +BundleInstall! +BundleClean +q
+    vim +PluginInstall! +PluginClean +q
 ```
 
 ## Removing (disabling) an included plugin
 
 Create `~/.vimrc.local` if it doesn't already exist.
 
-Add the UnBundle command to this line. It takes the same input as the Bundle line, so simply copy the line you want to disable and add 'Un' to the beginning.
+Add the UnBundle command to this line. It takes the same input as the Plugin line, so simply copy the line you want to disable and add 'Un' to the beginning.
 
 For example, disabling the 'AutoClose' and 'scrooloose/syntastic' plugins
 
@@ -250,7 +250,7 @@ For example, disabling the 'AutoClose' and 'scrooloose/syntastic' plugins
     echo UnBundle \'scrooloose/syntastic\' >> ~/.vimrc.bundles.local
 ```
 
-**Remember to run ':BundleClean!' after this to remove the existing directories**
+**Remember to run ':PluginClean!' after this to remove the existing directories**
 
 
 Here are a few of the plugins:
@@ -335,7 +335,7 @@ YouCompleteMe is another amazing completion engine. It is slightly more involved
 
 To enable YouCompleteMe add `youcompleteme` to your list of groups by overriding it in your `.vimrc.before.local` like so: `let g:spf13_bundle_groups=['general', 'programming', 'misc', 'scala', 'youcompleteme']` This is just an example. Remember to choose the other groups you want here.
 
-Once you have done this you will need to get Vundle to grab the latest code from git. You can do this by calling `:BundleInstall!`. You should see YouCompleteMe in the list.
+Once you have done this you will need to get Vundle to grab the latest code from git. You can do this by calling `:PluginInstall!`. You should see YouCompleteMe in the list.
 
 You will now have the code in your bundles directory and can proceed to compile the core. Change to the directory it has been downloaded to. If you have a vanilla install then `cd ~/.spf13-vim-3/.vim/bundle/YouCompleteMe/` should do the trick. You should see a file in this directory called install.sh. There are a few options to consider before running the installer:
 

--- a/README.markdown
+++ b/README.markdown
@@ -234,7 +234,7 @@ To add a new plugin, just add one line for each plugin you want to install. The 
 Once new plugins are added, they have to be installed.
 
 ```bash
-    vim +PluginInstall! +PluginClean +q
+    vim +PluginInstall! +PluginClean +qa
 ```
 
 ## Removing (disabling) an included plugin

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -164,8 +164,8 @@ setup_vundle() {
     vim \
         -u "$1" \
         "+set nomore" \
-        "+VundleInstall!" \
-        "+VundleClean" \
+        "+PluginInstall!" \
+        "+PluginClean" \
         "+qall"
 
     export SHELL="$system_shell"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -164,8 +164,8 @@ setup_vundle() {
     vim \
         -u "$1" \
         "+set nomore" \
-        "+BundleInstall!" \
-        "+BundleClean" \
+        "+VundleInstall!" \
+        "+VundleClean" \
         "+qall"
 
     export SHELL="$system_shell"

--- a/spf13-vim-windows-install.cmd
+++ b/spf13-vim-windows-install.cmd
@@ -49,4 +49,4 @@ IF NOT EXIST "%HOME%/.vim/bundle/vundle" (
   call cd %HOME%
 )
 
-call vim -u "%APP_PATH%/.vimrc.bundles" +BundleInstall! +BundleClean +qall
+call vim -u "%APP_PATH%/.vimrc.bundles" +PluginInstall! +PluginClean +qall

--- a/spf13-vim-windows-xp-install.cmd
+++ b/spf13-vim-windows-xp-install.cmd
@@ -47,4 +47,4 @@ call copy "%APP_PATH%\.vimrc.before" "%HOME%\.vimrc.before"
 call copy "%APP_PATH%\.vimrc.before.fork" "%HOME%\.vimrc.before.fork"
 
 @if not exist "%HOME%/.vim/bundle/vundle" call git clone https://github.com/gmarik/vundle.git "%HOME%/.vim/bundle/vundle"
-call vim -u "%APP_PATH%/.vimrc.bundles" - +BundleInstall! +BundleClean +qall
+call vim -u "%APP_PATH%/.vimrc.bundles" - +PluginInstall! +PluginClean +qall


### PR DESCRIPTION
Fixes #658. Vundle has deprecated use of BundleInstall, BundleClean, etc. Added +qa to all documentation references to quit all vim windows after installing/cleaning bundles.
