### PR TITLE
Could not resolve airline theme "solarized". Themes have been migrated to github.co m/vim-airline/vim-airline-themes

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1050,7 +1050,7 @@
 
         " See `:echo g:airline_theme_map` for some more choices
         " Default in terminal vim is 'dark'
-        if isdirectory(expand("~/.vim/bundle/vim-airline/"))
+        if isdirectory(expand("~/.vim/bundle/vim-airline/vim-airline-themes"))
             if !exists('g:airline_theme')
                 let g:airline_theme = 'solarized'
             endif


### PR DESCRIPTION
Tiny change to resolve alert: 'Could not resolve airline theme "solarized". Themes have been migrated to github.co m/vim-airline/vim-airline-themes.' while enter vim, since vim-airline made a update days ago
