### PR TITLE
Tiny change to fix vim-airline alert

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1050,7 +1050,7 @@
 
         " See `:echo g:airline_theme_map` for some more choices
         " Default in terminal vim is 'dark'
-        if isdirectory(expand("~/.vim/bundle/vim-airline/"))
+        if isdirectory(expand("~/.vim/bundle/vim-airline-themes/"))
             if !exists('g:airline_theme')
                 let g:airline_theme = 'solarized'
             endif

--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -118,7 +118,8 @@
             elseif exists('g:spf13_use_powerline') && exists('g:spf13_use_old_powerline')
                 Bundle 'Lokaltog/vim-powerline'
             else
-                Bundle 'bling/vim-airline'
+                Bundle 'vim-airline/vim-airline'
+                Bundle 'vim-airline/vim-airline-themes'
             endif
             Bundle 'powerline/fonts'
             Bundle 'bling/vim-bufferline'


### PR DESCRIPTION
Tiny change to fix "Could not resolve airline theme "solarized dark". Themes have been migrated to github.co m/vim-airline/vim-airline-themes" as vim-airline made an update days ago
