### PR TITLE
Support a global spf13-vim installation and user-specific overrides

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -50,6 +50,20 @@
         endif
     " }
 
+    " Set the Vim configuration directory {
+        " The spf13-vim configuration files may not be in the user's home
+        " directory, denoted by $HOME. So, assume that all of the other
+        " files are in the same directory as this file (.vimrc).
+        let g:spf13_global_config_dir = expand("<sfile>:p:h")
+
+        " Check whether spf13-vim is installed outside of the user's home
+        " directory.
+        let g:spf13_is_global_install = 0
+        if g:spf13_global_config_dir != expand("~")
+            let g:spf13_is_global_install = 1
+        endif
+    " }
+
     " Windows Compatible {
         " On Windows, also use '.vim' instead of 'vimfiles'; this makes synchronization
         " across (heterogeneous) systems easier.
@@ -68,14 +82,14 @@
 " }
 
 " Use before config if available {
-    if filereadable(expand("~/.vimrc.before"))
-        source ~/.vimrc.before
+    if filereadable(g:spf13_global_config_dir . '/.vimrc.before')
+        exec printf('source %s/.vimrc.before', g:spf13_global_config_dir)
     endif
 " }
 
 " Use bundles config {
-    if filereadable(expand("~/.vimrc.bundles"))
-        source ~/.vimrc.bundles
+    if filereadable(g:spf13_global_config_dir . '/.vimrc.bundles')
+        exec printf('source %s/.vimrc.bundles', g:spf13_global_config_dir)
     endif
 " }
 
@@ -177,7 +191,7 @@
 
 " Vim UI {
 
-    if !exists('g:override_spf13_bundles') && filereadable(expand("~/.vim/bundle/vim-colors-solarized/colors/solarized.vim"))
+    if !exists('g:override_spf13_bundles') && filereadable(g:spf13_vundle_dir . '/vim-colors-solarized/colors/solarized.vim')
         let g:solarized_termcolors=256
         let g:solarized_termtrans=1
         let g:solarized_contrast="normal"
@@ -504,17 +518,17 @@
     " }
 
     " PIV {
-        if isdirectory(expand("~/.vim/bundle/PIV"))
+        if isdirectory(g:spf13_vundle_dir . '/PIV')
             let g:DisableAutoPHPFolding = 0
             let g:PIVAutoClose = 0
         endif
     " }
 
     " Misc {
-        if isdirectory(expand("~/.vim/bundle/nerdtree"))
+        if isdirectory(g:spf13_vundle_dir . '/nerdtree')
             let g:NERDShutUp=1
         endif
-        if isdirectory(expand("~/.vim/bundle/matchit.zip"))
+        if isdirectory(g:spf13_vundle_dir . '/matchit.zip')
             let b:match_ignorecase = 1
         endif
     " }
@@ -573,7 +587,7 @@
     " }
 
     " NerdTree {
-        if isdirectory(expand("~/.vim/bundle/nerdtree"))
+        if isdirectory(g:spf13_vundle_dir . '/nerdtree')
             map <C-e> <plug>NERDTreeTabsToggle<CR>
             map <leader>e :NERDTreeFind<CR>
             nmap <leader>nt :NERDTreeFind<CR>
@@ -590,7 +604,7 @@
     " }
 
     " Tabularize {
-        if isdirectory(expand("~/.vim/bundle/tabular"))
+        if isdirectory(g:spf13_vundle_dir . '/tabular')
             nmap <Leader>a& :Tabularize /&<CR>
             vmap <Leader>a& :Tabularize /&<CR>
             nmap <Leader>a= :Tabularize /^[^=]*\zs=<CR>
@@ -612,7 +626,7 @@
 
     " Session List {
         set sessionoptions=blank,buffers,curdir,folds,tabpages,winsize
-        if isdirectory(expand("~/.vim/bundle/sessionman.vim/"))
+        if isdirectory(g:spf13_vundle_dir . '/sessionman.vim')
             nmap <leader>sl :SessionList<CR>
             nmap <leader>ss :SessionSave<CR>
             nmap <leader>sc :SessionClose<CR>
@@ -630,7 +644,7 @@
             let g:pymode = 0
         endif
 
-        if isdirectory(expand("~/.vim/bundle/python-mode"))
+        if isdirectory(g:spf13_vundle_dir . '/python-mode')
             let g:pymode_lint_checkers = ['pyflakes']
             let g:pymode_trim_whitespaces = 0
             let g:pymode_options = 0
@@ -639,7 +653,7 @@
     " }
 
     " ctrlp {
-        if isdirectory(expand("~/.vim/bundle/ctrlp.vim/"))
+        if isdirectory(g:spf13_vundle_dir . '/ctrlp.vim')
             let g:ctrlp_working_path_mode = 'ra'
             nnoremap <silent> <D-t> :CtrlP<CR>
             nnoremap <silent> <D-r> :CtrlPMRU<CR>
@@ -670,7 +684,7 @@
                 \ 'fallback': s:ctrlp_fallback
             \ }
 
-            if isdirectory(expand("~/.vim/bundle/ctrlp-funky/"))
+            if isdirectory(g:spf13_vundle_dir . '/ctrlp-funky')
                 " CtrlP extensions
                 let g:ctrlp_extensions = ['funky']
 
@@ -681,19 +695,19 @@
     "}
 
     " TagBar {
-        if isdirectory(expand("~/.vim/bundle/tagbar/"))
+        if isdirectory(g:spf13_vundle_dir . '/tagbar')
             nnoremap <silent> <leader>tt :TagbarToggle<CR>
         endif
     "}
 
     " Rainbow {
-        if isdirectory(expand("~/.vim/bundle/rainbow/"))
+        if isdirectory(g:spf13_vundle_dir . '/rainbow')
             let g:rainbow_active = 1 "0 if you want to enable it later via :RainbowToggle
         endif
     "}
 
     " Fugitive {
-        if isdirectory(expand("~/.vim/bundle/vim-fugitive/"))
+        if isdirectory(g:spf13_vundle_dir . '/vim-fugitive')
             nnoremap <silent> <leader>gs :Gstatus<CR>
             nnoremap <silent> <leader>gd :Gdiff<CR>
             nnoremap <silent> <leader>gc :Gcommit<CR>
@@ -986,7 +1000,7 @@
                     \ count(g:spf13_bundle_groups, 'neocomplete')
 
             " Use honza's snippets.
-            let g:neosnippet#snippets_directory='~/.vim/bundle/vim-snippets/snippets'
+            let g:neosnippet#snippets_directory = g:spf13_vundle_dir . '/vim-snippets/snippets'
 
             " Enable neosnippet snipmate compatibility mode
             let g:neosnippet#enable_snipmate_compatibility = 1
@@ -1017,7 +1031,7 @@
     endif
 
     " UndoTree {
-        if isdirectory(expand("~/.vim/bundle/undotree/"))
+        if isdirectory(g:spf13_vundle_dir . '/undotree')
             nnoremap <Leader>u :UndotreeToggle<CR>
             " If undotree is opened, it is likely one wants to interact with it.
             let g:undotree_SetFocusWhenToggle=1
@@ -1025,7 +1039,7 @@
     " }
 
     " indent_guides {
-        if isdirectory(expand("~/.vim/bundle/vim-indent-guides/"))
+        if isdirectory(g:spf13_vundle_dir . '/vim-indent-guides')
             let g:indent_guides_start_level = 2
             let g:indent_guides_guide_size = 1
             let g:indent_guides_enable_on_vim_startup = 1
@@ -1050,7 +1064,7 @@
 
         " See `:echo g:airline_theme_map` for some more choices
         " Default in terminal vim is 'dark'
-        if isdirectory(expand("~/.vim/bundle/vim-airline/"))
+        if isdirectory(g:spf13_vundle_dir . '/vim-airline')
             if !exists('g:airline_theme')
                 let g:airline_theme = 'solarized'
             endif
@@ -1188,9 +1202,9 @@
 
     function! s:IsSpf13Fork()
         let s:is_fork = 0
-        let s:fork_files = ["~/.vimrc.fork", "~/.vimrc.before.fork", "~/.vimrc.bundles.fork"]
+        let s:fork_files = [".vimrc.fork", ".vimrc.before.fork", ".vimrc.bundles.fork"]
         for fork_file in s:fork_files
-            if filereadable(expand(fork_file, ":p"))
+            if filereadable(g:spf13_global_config_dir . '/' . fork_file, ":p")
                 let s:is_fork = 1
                 break
             endif
@@ -1203,49 +1217,60 @@
     endfunction
      
     function! s:EditSpf13Config()
-        call <SID>ExpandFilenameAndExecute("tabedit", "~/.vimrc")
-        call <SID>ExpandFilenameAndExecute("vsplit", "~/.vimrc.before")
-        call <SID>ExpandFilenameAndExecute("vsplit", "~/.vimrc.bundles")
+        call <SID>ExpandFilenameAndExecute("tabedit", g:spf13_global_config_dir . '/.vimrc')
+        call <SID>ExpandFilenameAndExecute("vsplit", g:spf13_global_config_dir . '/.vimrc.before')
+        call <SID>ExpandFilenameAndExecute("vsplit", g:spf13_global_config_dir . '/.vimrc.bundles')
      
         execute bufwinnr(".vimrc") . "wincmd w"
-        call <SID>ExpandFilenameAndExecute("split", "~/.vimrc.local")
+        call <SID>ExpandFilenameAndExecute("split", g:spf13_global_config_dir . '/.vimrc.local')
         wincmd l
-        call <SID>ExpandFilenameAndExecute("split", "~/.vimrc.before.local")
+        call <SID>ExpandFilenameAndExecute("split", g:spf13_global_config_dir . '/.vimrc.before.local')
         wincmd l
-        call <SID>ExpandFilenameAndExecute("split", "~/.vimrc.bundles.local")
+        call <SID>ExpandFilenameAndExecute("split", g:spf13_global_config_dir . '/.vimrc.bundles.local')
      
         if <SID>IsSpf13Fork()
             execute bufwinnr(".vimrc") . "wincmd w"
-            call <SID>ExpandFilenameAndExecute("split", "~/.vimrc.fork")
+            call <SID>ExpandFilenameAndExecute("split", g:spf13_global_config_dir . '/.vimrc.fork')
             wincmd l
-            call <SID>ExpandFilenameAndExecute("split", "~/.vimrc.before.fork")
+            call <SID>ExpandFilenameAndExecute("split", g:spf13_global_config_dir . '/.vimrc.before.fork')
             wincmd l
-            call <SID>ExpandFilenameAndExecute("split", "~/.vimrc.bundles.fork")
+            call <SID>ExpandFilenameAndExecute("split", g:spf13_global_config_dir . '/.vimrc.bundles.fork')
         endif
      
         execute bufwinnr(".vimrc.local") . "wincmd w"
     endfunction
      
     execute "noremap " . s:spf13_edit_config_mapping " :call <SID>EditSpf13Config()<CR>"
-    execute "noremap " . s:spf13_apply_config_mapping . " :source ~/.vimrc<CR>"
+    execute "noremap " . s:spf13_apply_config_mapping . " :exec source " . g:spf13_global_config_dir . "/.vimrc<CR>"
 " }
 
 " Use fork vimrc if available {
-    if filereadable(expand("~/.vimrc.fork"))
-        source ~/.vimrc.fork
+    if filereadable(g:spf13_global_config_dir . '/.vimrc.fork')
+        exec printf('source %s/.vimrc.fork', g:spf13_global_config_dir)
     endif
 " }
 
 " Use local vimrc if available {
-    if filereadable(expand("~/.vimrc.local"))
-        source ~/.vimrc.local
+    if filereadable(g:spf13_global_config_dir . '/.vimrc.local')
+        exec printf('source %s/.vimrc.local', g:spf13_global_config_dir)
+    endif
+" }
+
+" Use the user-specific local vimrc if available {
+    if g:spf13_is_global_install && filereadable(expand("~/.vimrc.local.user"))
+        source ~/.vimrc.local.user
     endif
 " }
 
 " Use local gvimrc if available and gui is running {
     if has('gui_running')
-        if filereadable(expand("~/.gvimrc.local"))
-            source ~/.gvimrc.local
+        if filereadable(g:spf13_global_config_dir . '/.gvimrc.local')
+            exec printf('source %s/.gvimrc.local', g:spf13_global_config_dir)
+        endif
+
+        " Use the user-specific local vimrc if available
+        if g:spf13_is_global_install && filereadable(expand("~/.gvimrc.local.user"))
+            source ~/.gvimrc.local.user
         endif
     endif
 " }

--- a/.vimrc.before
+++ b/.vimrc.before
@@ -76,7 +76,7 @@
     "   autocmd VimEnter,Colorscheme * :hi IndentGuidesEven guibg=#404040 ctermbg=234
 
     " Leave the default font and size in GVim
-    " To set your own font, do it from ~/.vimrc.local
+    " To set your own font, do it from .vimrc.local
     "   let g:spf13_no_big_font = 1
 
     " Disable  omni complete
@@ -99,13 +99,19 @@
 " }
 
 " Use fork before if available {
-    if filereadable(expand("~/.vimrc.before.fork"))
-        source ~/.vimrc.before.fork
+    if filereadable(g:spf13_global_config_dir . '/.vimrc.before.fork')
+        exec printf('source %s/.vimrc.before.fork', g:spf13_global_config_dir)
     endif
 " }
 
 " Use local before if available {
-    if filereadable(expand("~/.vimrc.before.local"))
-        source ~/.vimrc.before.local
+    if filereadable(g:spf13_global_config_dir . '/.vimrc.before.local')
+        exec printf('source %s/.vimrc.before.local', g:spf13_global_config_dir)
+    endif
+" }
+
+" Use the user-specific local before if available {
+    if g:spf13_is_global_install && filereadable(expand("~/.vimrc.before.local.user"))
+        source ~/.vimrc.before.local.user
     endif
 " }

--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -15,7 +15,7 @@
 "   This file imports the various plugins of spf13. If you
 "   wish to alter which groups are imported, see vimrc.before.
 "   If you wish to add or remove individual bundles, create
-"   ~/.vimrc.bundles.local and `Bundle` or `UnBundle` as needed
+"   .vimrc.bundles.local and `Bundle` or `UnBundle` as needed
 "   from there.
 "
 "   You can find me at http://spf13.com
@@ -26,6 +26,12 @@
     " Basics {
         set nocompatible        " Must be first line
         set background=dark     " Assume a dark background
+    " }
+
+    " Assign the bundle storage directory {
+        " g:spf13_global_config_dir is auto-defined in .vimrc or
+        " .vimrc.bundles.default
+        let g:spf13_vundle_dir = g:spf13_global_config_dir . '/.vim/bundle/vundle'
     " }
 
     " Windows Compatible {
@@ -53,10 +59,19 @@
     " }
 
     " Setup Bundle Support {
-        " The next three lines ensure that the ~/.vim/bundle/ system works
+        " This section ensure that the .vim/bundle/ system works
         filetype off
-        set rtp+=~/.vim/bundle/vundle
-        call vundle#rc()
+
+        " Set the runtimepath for the bootstrap
+        exec printf('set runtimepath+=%s', g:spf13_vundle_dir)
+
+        " Set the runtimepath, post-bootstrap, wherein the vundle
+        " plugin is relocated from .vim/bundle/vundle to
+        " .vim/bundle/vundle/vundle
+        exec printf('set runtimepath+=%s/vundle', g:spf13_vundle_dir)
+
+        " Initialize Vundle
+        call vundle#rc(g:spf13_vundle_dir)
     " }
 
     " Add an UnBundle command {
@@ -114,7 +129,7 @@
             Bundle 'vim-scripts/sessionman.vim'
             Bundle 'matchit.zip'
             if (has("python") || has("python3")) && exists('g:spf13_use_powerline') && !exists('g:spf13_use_old_powerline')
-                Bundle 'Lokaltog/powerline', {'rtp':'/powerline/bindings/vim'}
+                Bundle 'Lokaltog/powerline', {'runtimepath':'/powerline/bindings/vim'}
             elseif exists('g:spf13_use_powerline') && exists('g:spf13_use_old_powerline')
                 Bundle 'Lokaltog/vim-powerline'
             else
@@ -170,8 +185,8 @@
             Bundle 'garbas/vim-snipmate'
             Bundle 'honza/vim-snippets'
             " Source support_function.vim to support vim-snippets.
-            if filereadable(expand("~/.vim/bundle/vim-snippets/snippets/support_functions.vim"))
-                source ~/.vim/bundle/vim-snippets/snippets/support_functions.vim
+            if filereadable(g:spf13_vundle_dir . '/vim-snippets/snippets/support_functions.vim')
+                exec printf('source %s/vim-snippets/snippets/support_functions.vim', g:spf13_vundle_dir)
             endif
         elseif count(g:spf13_bundle_groups, 'youcompleteme')
             Bundle 'Valloric/YouCompleteMe'
@@ -298,13 +313,19 @@
 " }
 
 " Use fork bundles config if available {
-    if filereadable(expand("~/.vimrc.bundles.fork"))
-        source ~/.vimrc.bundles.fork
+    if filereadable(g:spf13_global_config_dir . '/.vimrc.bundles.fork')
+        exec printf('source %s/.vimrc.bundles.fork', g:spf13_global_config_dir)
     endif
 " }
 
 " Use local bundles config if available {
-    if filereadable(expand("~/.vimrc.bundles.local"))
-        source ~/.vimrc.bundles.local
+    if filereadable(g:spf13_global_config_dir . '/.vimrc.bundles.local')
+        exec printf('source %s/.vimrc.bundles.local', g:spf13_global_config_dir)
     endif
 " }
+
+" Do not attempt to load a user-specific bundles configuration file since the
+" Vundle storage directory is located within the global installation folder
+" and user-specific changes will have adverse affects on all user's in the
+" system. In other words, if spf13-vim is installed globally, users are not
+" able to add/remove bundles.

--- a/.vimrc.bundles.default
+++ b/.vimrc.bundles.default
@@ -5,6 +5,13 @@
         " directory, denoted by $HOME. So, assume that all of the other
         " files are in the same directory as this file (.vimrc).
         let g:spf13_global_config_dir = expand("<sfile>:p:h")
+
+        " Check whether spf13-vim is installed outside of the user's home
+        " directory.
+        let g:spf13_is_global_install = 0
+        if g:spf13_global_config_dir != expand("~")
+            let g:spf13_is_global_install = 1
+        endif
     " }
 
 " }

--- a/.vimrc.bundles.default
+++ b/.vimrc.bundles.default
@@ -1,14 +1,25 @@
+" Environment {
+
+    " Set the Vim configuration directory {
+        " The spf13-vim configuration files may not be in the user's home
+        " directory, denoted by $HOME. So, assume that all of the other
+        " files are in the same directory as this file (.vimrc).
+        let g:spf13_global_config_dir = expand("<sfile>:p:h")
+    " }
+
+" }
+
 " Default Bundles {
 
     " Use before config if available {
-        if filereadable(expand("~/.vimrc.before"))
-            source ~/.vimrc.before
+        if filereadable(g:spf13_global_config_dir . '/.vimrc.before')
+            exec printf('source %s/.vimrc.before', g:spf13_global_config_dir)
         endif
     " }
 
     " Use bundles config {
-        if filereadable(expand("~/.vimrc.bundles"))
-            source ~/.vimrc.bundles
+        if filereadable(g:spf13_global_config_dir . '/.vimrc.bundles')
+            exec printf('source %s/.vimrc.bundles', g:spf13_global_config_dir)
         endif
     " }
 " }


### PR DESCRIPTION
On my workstation and some remote servers, I use Vim as a user other than myself (notably as root via sudo, but sometimes other users), and I want to have the same spf13-vim configuration across users on the same system. This pull request is a first take at distinguishing global and user-specific configurations on a given system.

If the spf13-vim base configuration files (.vimrc, .vimrc.bundles, etc.) are not stored in the current user's home directory, then a global configuration is assumed. If the configuration is global, then user-specific overrides are stored in $HOME/{spf13_vim_config}.user e.g., $HOME/.vimrc.local.user, $HOME/.vimrc.before.local.user, etc.

I can write documentation after this request is approved.
