### PR TITLE
Do not include cursorline in the default configuration since it incurs a significant CPU hit

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -188,8 +188,6 @@
     set tabpagemax=15               " Only show 15 tabs
     set showmode                    " Display the current mode
 
-    set cursorline                  " Highlight current line
-
     highlight clear SignColumn      " SignColumn should match background
     highlight clear LineNr          " Current line number row will have same background color in relative mode
     "highlight clear CursorLineNr    " Remove highlight color from current line number


### PR DESCRIPTION
Prior to this commit, I would often observe Vim using 100% CPU while scrolling through a basic PHP or CSS file with the common, "j" and "k" motion commands. After profiling Vim under various configurations, I isolated the cause to "set cursorline" in .vimrc. Upon disabling cursorline, I was able to navigate the same files at ~10% CPU utilization.

":help cursorline" shows the following

>  Highlight the screen line of the cursor with CursorLine |hl-CursorLine|.  Useful to easily spot the cursor.  Will make screen redrawing slower. When Visual mode is active the highlighting isn't used to make it easier to see the selected text.
