### PR TITLE
fix: 'rm: cannot remove ~/.vim: Is a directory'

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -13,6 +13,6 @@ die() {
 
 rm $HOME/.vimrc
 rm $HOME/.vimrc.bundles
-rm $HOME/.vim
+rm -rf $HOME/.vim
 
 rm -rf $app_dir


### PR DESCRIPTION
$HOME/.vim is a directory
