### PR TITLE
Updated vundle repo

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -74,7 +74,7 @@
 " Bundles {
 
     " Deps {
-        Bundle 'gmarik/vundle'
+        Bundle 'VundleVim/vundle'
         Bundle 'MarcWeber/vim-addon-mw-utils'
         Bundle 'tomtom/tlib_vim'
         if executable('ag')


### PR DESCRIPTION
As the actual development of Vundle has been moved to https://github.com/VundleVim/Vundle.vim, updated the reference in the config file.
