### PR TITLE
.vimrc.local is not corresponding file as the following

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -239,7 +239,7 @@ Once new plugins are added, they have to be installed.
 
 ## Removing (disabling) an included plugin
 
-Create `~/.vimrc.local` if it doesn't already exist.
+Create `~/.vimrc.bundles.local` if it doesn't already exist.
 
 Add the UnBundle command to this line. It takes the same input as the Bundle line, so simply copy the line you want to disable and add 'Un' to the beginning.
 


### PR DESCRIPTION
.vimrc.local is not corresponding file as the following,  .vimrc.bundles.local is the right one.
![](https://cloud.githubusercontent.com/assets/587955/17048547/600b4d50-5019-11e6-8ba9-9ff7290dbe27.png)
