### PR TITLE
Replace beyondwords/vim-twig by the maintained fork of lumiliet

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -195,7 +195,7 @@
         if count(g:spf13_bundle_groups, 'php')
             Bundle 'spf13/PIV'
             Bundle 'arnaud-lb/vim-php-namespace'
-            Bundle 'beyondwords/vim-twig'
+            Bundle 'lumiliet/vim-twig'
         endif
     " }
 


### PR DESCRIPTION
Small repo change
