### PR TITLE
Add basic support for typescript

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -216,6 +216,7 @@
             Bundle 'pangloss/vim-javascript'
             Bundle 'briancollins/vim-jst'
             Bundle 'kchmck/vim-coffee-script'
+            Bundle 'leafgarland/typescript-vim'
         endif
     " }
 


### PR DESCRIPTION
In the javascript bundle I've added the typescript plugin from
https://github.com/leafgarland/typescript-vim

No other settings or overrides have been made.

Addresses issue #979.