### PR TITLE
Remove HTML-AutoCloseTag plugin

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -244,7 +244,6 @@
 
     " HTML {
         if count(g:spf13_bundle_groups, 'html')
-            Bundle 'amirh/HTML-AutoCloseTag'
             Bundle 'hail2u/vim-css3-syntax'
             Bundle 'gorodinskiy/vim-coloresque'
             Bundle 'tpope/vim-haml'


### PR DESCRIPTION
This doesn't plugin doesn't seem supported anymore and the repo is 404'ing. The vim-script repo could be used but people have been reporting this plugin doesn't even work in #552 so I suggest removing it.