### PR TITLE
use another html auto close tag

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -244,7 +244,7 @@
 
     " HTML {
         if count(g:spf13_bundle_groups, 'html')
-            Bundle 'amirh/HTML-AutoCloseTag'
+            Bundle 'alvan/vim-closetag'
             Bundle 'hail2u/vim-css3-syntax'
             Bundle 'gorodinskiy/vim-coloresque'
             Bundle 'tpope/vim-haml'


### PR DESCRIPTION
I've briefly used this one but seems to work well than others. Plus `amirh/HTML-AutoCloseTag` seems to be dead now