### PR TITLE
uninstall: remove the directory using `-rf` flags

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -11,8 +11,8 @@ die() {
     exit 1
 }
 
-rm $HOME/.vimrc
-rm $HOME/.vimrc.bundles
-rm $HOME/.vim
+rm -f $HOME/.vimrc
+rm -f $HOME/.vimrc.bundles
+rm -rf $HOME/.vim
 
 rm -rf $app_dir


### PR DESCRIPTION
To remove a directory, we have to use `rm -rf <dir>`, just using `rm <dir>` will give an error. Also, introduce the `-f` flag to ignore the warnings. Also, remove an extra line.