### PR TITLE
[SOLVED] Update plugins for vim-buftabline & HTML-AutoCloseTag

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -101,6 +101,7 @@
 
     " General {
         if count(g:spf13_bundle_groups, 'general')
+            Bundle 'ap/vim-buftabline'
             Bundle 'scrooloose/nerdtree'
             Bundle 'altercation/vim-colors-solarized'
             Bundle 'spf13/vim-colors'

--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -245,7 +245,7 @@
 
     " HTML {
         if count(g:spf13_bundle_groups, 'html')
-            Bundle 'amirh/HTML-AutoCloseTag'
+            Bundle 'vim-scripts/HTML-AutoCloseTag'
             Bundle 'hail2u/vim-css3-syntax'
             Bundle 'gorodinskiy/vim-coloresque'
             Bundle 'tpope/vim-haml'


### PR DESCRIPTION
* General
```
+ Bundle 'ap/vim-buftabline'
```

* HTML
```
- Bundle 'amirh/HTML-AutoCloseTag'
+ Bundle 'vim-scripts/HTML-AutoCloseTag'
```