### PR TITLE
.vim is a dir,rm it must use -rf

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -13,6 +13,6 @@ die() {
 
 rm $HOME/.vimrc
 rm $HOME/.vimrc.bundles
-rm $HOME/.vim
+rm -rf $HOME/.vim
 
 rm -rf $app_dir


### PR DESCRIPTION
I use uninstall.sh ,find .vim is dir ,and uninstall use rm and no ``` -rf ``` args , so I add -rf args ,