### PR TITLE
Bugfix: for failing Bundle Install

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -244,7 +244,7 @@
 
     " HTML {
         if count(g:spf13_bundle_groups, 'html')
-            Bundle 'amirh/HTML-AutoCloseTag'
+            Bundle 'vim-scripts/HTML-AutoCloseTag'
             Bundle 'hail2u/vim-css3-syntax'
             Bundle 'gorodinskiy/vim-coloresque'
             Bundle 'tpope/vim-haml'


### PR DESCRIPTION
if you run command `vim +BundleInstall! +BundleClean +q`
it fails because the Repo amirh/HTML-AutoCloseTag (https://github.com/amirh/HTML-AutoCloseTag) no longer exists.