### PR TITLE
Replace deprecated plugin amirh/HTML-AutoCloseTag with mirror

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -244,7 +244,7 @@
 
     " HTML {
         if count(g:spf13_bundle_groups, 'html')
-            Bundle 'amirh/HTML-AutoCloseTag'
+            Bundle 'heracek/HTML-AutoCloseTag'
             Bundle 'hail2u/vim-css3-syntax'
             Bundle 'gorodinskiy/vim-coloresque'
             Bundle 'tpope/vim-haml'


### PR DESCRIPTION
When updating plugins, the bundle `amirh/HTML-AutoCloseTag` fails as the git repo seems to have been removed.  There is a mirror of it here `heracek/HTML-AutoCloseTag`.  Use that instead.